### PR TITLE
Install AForge through NuGet & drop unused Math.Net.Numerics package

### DIFF
--- a/LitePlacer/LitePlacer.csproj
+++ b/LitePlacer/LitePlacer.csproj
@@ -100,35 +100,27 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AForge, Version=2.2.5.0, Culture=neutral, PublicKeyToken=c1db6ff4eaa06aeb, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\AForge.NET\Framework\Release\AForge.dll</HintPath>
-    </Reference>
-    <Reference Include="AForge.Controls, Version=2.2.5.0, Culture=neutral, PublicKeyToken=a8ac264d1dc6b9d9, processorArchitecture=MSIL" />
-    <Reference Include="AForge.DebuggerVisualizers %282010%29, Version=1.0.0.0, Culture=neutral, PublicKeyToken=0646c9a9e79f6b03, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\AForge.NET\Framework\Release\AForge.DebuggerVisualizers (2010).dll</HintPath>
+      <HintPath>..\packages\AForge.2.2.5\lib\AForge.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="AForge.Imaging, Version=2.2.5.0, Culture=neutral, PublicKeyToken=ba8ddea9676ca48b, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\AForge.NET\Framework\Release\AForge.Imaging.dll</HintPath>
+      <HintPath>..\packages\AForge.Imaging.2.2.5\lib\AForge.Imaging.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="AForge.Math, Version=2.2.5.0, Culture=neutral, PublicKeyToken=abba2e25397ee8c9, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\AForge.NET\Framework\Release\AForge.Math.dll</HintPath>
+      <HintPath>..\packages\AForge.Math.2.2.5\lib\AForge.Math.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="AForge.Video, Version=2.2.5.0, Culture=neutral, PublicKeyToken=cbfb6e07d173c401, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\AForge.NET\Framework\Release\AForge.Video.dll</HintPath>
+      <HintPath>..\packages\AForge.Video.2.2.5\lib\AForge.Video.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="AForge.Video.DirectShow, Version=2.2.5.0, Culture=neutral, PublicKeyToken=61ea4348d43881b7, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\AForge.NET\Framework\Release\AForge.Video.DirectShow.dll</HintPath>
+      <HintPath>..\packages\AForge.Video.DirectShow.2.2.5\lib\AForge.Video.DirectShow.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="HomographyEstimation">
       <HintPath>..\packages\HomographyEstimation\HomographyEstimation.dll</HintPath>
-    </Reference>
-    <Reference Include="MathNet.Numerics">
-      <HintPath>..\packages\MathNet.Numerics.3.5.0\lib\net40\MathNet.Numerics.dll</HintPath>
     </Reference>
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />

--- a/LitePlacer/MainForm.cs
+++ b/LitePlacer/MainForm.cs
@@ -24,7 +24,6 @@ using System.Windows.Media;
 using System.Windows.Input;
 using System.Net;
 
-using MathNet.Numerics;
 using HomographyEstimation;
 
 using AForge;

--- a/LitePlacer/packages.config
+++ b/LitePlacer/packages.config
@@ -1,4 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MathNet.Numerics" version="3.5.0" targetFramework="net40" />
+  <package id="AForge" version="2.2.5" targetFramework="net40" />
+  <package id="AForge.Imaging" version="2.2.5" targetFramework="net40" />
+  <package id="AForge.Math" version="2.2.5" targetFramework="net40" />
+  <package id="AForge.Video" version="2.2.5" targetFramework="net40" />
+  <package id="AForge.Video.DirectShow" version="2.2.5" targetFramework="net40" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -5,14 +5,4 @@ LitePlacer pick andpPlace machine user interface and control software
 
 [Introduction video on Youtube](https://www.youtube.com/watch?v=0bYrwi3UA_A)
 
-To get the code to compile: 
-
-* Install AForge.NET
-
-* In solution explorer-LitePlacer-References, delete references to Math.Net.Numerics and to HomographyEstimation.dll.
-
-* Add reference to <your LitePlacer software directory>/packages/HomographyEstimation/HomographyEstimation.dll
-
-* Run the following command in the Tools-NuGet Package Manager-Package Manager Console: PM> Install-Package MathNet.Numerics
-
 To avoid issues in debugging, turn off the "Enable property evaluation and other implicit function calls" option in Tools->Options->Debugging 


### PR DESCRIPTION
Simplify the steps to build the project by:
1. Installing AForge.NET through NuGet
2. Removing the unused MathNet.Numerics package

Ideally, the whole `packages` folder should be ignored in the repo, but `HomographyEstimation.dll` doesn't seem to be available through NuGet.
