### PR TITLE
Needle Wobble correction using CNC domain

### DIFF
--- a/LitePlacer/MainForm.Designer.cs
+++ b/LitePlacer/MainForm.Designer.cs
@@ -335,7 +335,6 @@
             this.ZUp_button = new System.Windows.Forms.Button();
             this.ZDown_button = new System.Windows.Forms.Button();
             this.GotoUpCamPosition_button = new System.Windows.Forms.Button();
-            this.SetUpCamPosition_button = new System.Windows.Forms.Button();
             this.label99 = new System.Windows.Forms.Label();
             this.label98 = new System.Windows.Forms.Label();
             this.UpcamPositionY_textBox = new System.Windows.Forms.TextBox();
@@ -1719,7 +1718,6 @@
             this.tabPageSetupCameras.Controls.Add(this.ZUp_button);
             this.tabPageSetupCameras.Controls.Add(this.ZDown_button);
             this.tabPageSetupCameras.Controls.Add(this.GotoUpCamPosition_button);
-            this.tabPageSetupCameras.Controls.Add(this.SetUpCamPosition_button);
             this.tabPageSetupCameras.Controls.Add(this.label99);
             this.tabPageSetupCameras.Controls.Add(this.label98);
             this.tabPageSetupCameras.Controls.Add(this.UpcamPositionY_textBox);
@@ -4105,17 +4103,6 @@
             this.GotoUpCamPosition_button.UseVisualStyleBackColor = true;
             this.GotoUpCamPosition_button.Click += new System.EventHandler(this.GotoUpCamPosition_button_Click);
             // 
-            // SetUpCamPosition_button
-            // 
-            this.SetUpCamPosition_button.Location = new System.Drawing.Point(419, 524);
-            this.SetUpCamPosition_button.Name = "SetUpCamPosition_button";
-            this.SetUpCamPosition_button.Size = new System.Drawing.Size(66, 23);
-            this.SetUpCamPosition_button.TabIndex = 72;
-            this.SetUpCamPosition_button.Text = "Set";
-            this.toolTip1.SetToolTip(this.SetUpCamPosition_button, "Sets Up camera location");
-            this.SetUpCamPosition_button.UseVisualStyleBackColor = true;
-            this.SetUpCamPosition_button.Click += new System.EventHandler(this.SetUpCamPosition_button_Click);
-            // 
             // label99
             // 
             this.label99.AutoSize = true;
@@ -4142,6 +4129,7 @@
             this.UpcamPositionY_textBox.TabIndex = 69;
             this.UpcamPositionY_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.UpcamPositionY_textBox_KeyPress);
             this.UpcamPositionY_textBox.Leave += new System.EventHandler(this.UpcamPositionY_textBox_Leave);
+            this.toolTip1.SetToolTip(this.UpcamPositionY_textBox, "This value is set during Needle Setup.\r\nWhile allowed, editing is not advised.");
             // 
             // UpcamPositionX_textBox
             // 
@@ -4151,6 +4139,7 @@
             this.UpcamPositionX_textBox.TabIndex = 68;
             this.UpcamPositionX_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.UpcamPositionX_textBox_KeyPress);
             this.UpcamPositionX_textBox.Leave += new System.EventHandler(this.UpcamPositionX_textBox_Leave);
+            this.toolTip1.SetToolTip(this.UpcamPositionX_textBox, "This value is set during Needle Setup.\r\nWhile allowed, editing is not advised.");
             // 
             // NeedleOffsetY_textBox
             // 
@@ -7930,7 +7919,6 @@
 		private System.Windows.Forms.CheckBox DownCameraDrawBox_checkBox;
 		private System.Windows.Forms.CheckBox Overlay_checkBox;
 		private System.Windows.Forms.Button GotoUpCamPosition_button;
-		private System.Windows.Forms.Button SetUpCamPosition_button;
 		private System.Windows.Forms.Label label99;
 		private System.Windows.Forms.Label label98;
 		private System.Windows.Forms.TextBox UpcamPositionY_textBox;

--- a/LitePlacer/MainForm.cs
+++ b/LitePlacer/MainForm.cs
@@ -3495,6 +3495,11 @@ namespace LitePlacer
                     double Dist;
                     double Tries = 0;
                     int res;
+                    // We don't want slack compensation on save the present state to restore
+                    bool SaveSlackCompState = Cnc.SlackCompensation;
+                    bool SaveSlackCompAState = Cnc.SlackCompensationA;
+                    Cnc.SlackCompensation = false;
+                    Cnc.SlackCompensationA = false;
                     //Using this technique allows an exit in the middle of the loop.
                     //We can exit right away if the distance is good.  If not, we can move and take another reading.
                     while (true)
@@ -3527,6 +3532,9 @@ namespace LitePlacer
                             "No Circle found",
                             MessageBoxButtons.OK);
                     }
+                    //Restore Slack Compensation states
+                    Cnc.SlackCompensation = SaveSlackCompState;
+                    Cnc.SlackCompensationA = SaveSlackCompAState;
                     Offset2Method_button.Text = "Start";
                     SelectCamera(DownCamera);
                     SetCurrentCameraParameters();

--- a/LitePlacer/Needle.cs
+++ b/LitePlacer/Needle.cs
@@ -204,6 +204,11 @@ namespace LitePlacer
 			double Y = 0;
             double Dist;
 			int res = 0; ;
+            // We don't want slack compensation on save the present state to restore
+            bool SaveSlackCompState = Cnc.SlackCompensation;
+            bool SaveSlackCompAState = Cnc.SlackCompensationA;
+            Cnc.SlackCompensation = false;
+            Cnc.SlackCompensationA = false;
             for (int i = 0; i <= 3600; i = i + 225)
             {
                 NeedlePoint Point = new NeedlePoint();
@@ -252,6 +257,9 @@ namespace LitePlacer
 				// MainForm.DisplayText("A: " + Point.Angle.ToString("0.000") + ", X: " + Point.X.ToString("0.000") + ", Y: " + Point.Y.ToString("0.000"));
                 CalibrationPoints.Add(Point);
             }
+            //Restore Slack Compensation states
+            Cnc.SlackCompensation = SaveSlackCompState;
+            Cnc.SlackCompensationA = SaveSlackCompAState;
             /*********************************************************************************
              * Here we are going to calculate the center of the calibration points.  It will
              * be the center of the line connecting each two points that are 180 degrees apart.


### PR DESCRIPTION
There are several changes to the needle wobble algorithms.
The Offset2Method_button_Click function was the first to be changed
and has an extensive discussion at the top.  The biggest change is to
store the current CNC position in the needle CalibrationPoints array.
The CNC position of the down camera over the up camera is calculated
(we can't actually move there) and is used to calculate the Needle Offset
for every calibration point.  The interpolation routines still work.
The other big change is to programmatically move the needle to the
center of the camera for every measurement.  This should give the highest
accuracy in the CNC domain.  Finally, the "Set" button has been removed
for the Up Camera location.  It is set as part of the Needle Setup.
