### PR TITLE
Exposing CNC.SlackCompensationDistance as a setting to allow user con…

### DIFF
--- a/LitePlacer/AppSettings.cs
+++ b/LitePlacer/AppSettings.cs
@@ -40,6 +40,7 @@ namespace LitePlacer
         public int CNC_NormalJogSpeed = 1000;
         public string CNC_SerialPort = "";
         public bool CNC_SlackCompensation = false;
+        public double CNC_SlackCompensationDistance = 0.4;
         public bool CNC_SlackCompensationA = false;
         public decimal CNC_SmallMovementSpeed = 150;
         public double CNC_SquareCorrection = 0;
@@ -256,6 +257,7 @@ namespace LitePlacer
                 s.CNC_NormalJogSpeed = Properties.Settings.Default.CNC_NormalJogSpeed;
                 s.CNC_SerialPort = Properties.Settings.Default.CNC_SerialPort;
                 s.CNC_SlackCompensation = Properties.Settings.Default.CNC_SlackCompensation;
+                s.CNC_SlackCompensationDistance = Properties.Settings.Default.CNC_SlackCompensationDistance;
                 s.CNC_SlackCompensationA = Properties.Settings.Default.CNC_SlackCompensationA;
                 s.CNC_SmallMovementSpeed = Properties.Settings.Default.CNC_SmallMovementSpeed;
                 s.CNC_SquareCorrection = Properties.Settings.Default.CNC_SquareCorrection;

--- a/LitePlacer/CNC.cs
+++ b/LitePlacer/CNC.cs
@@ -246,7 +246,7 @@ namespace LitePlacer
         }
 
         public bool SlackCompensation { get; set; }
-        private double SlackCompensationDistance = 0.4;
+        public double SlackCompensationDistance { get; set; }
 
         public bool SlackCompensationA { get; set; }
         private double SlackCompensationDistanceA = 5.0;

--- a/LitePlacer/MainForm.Designer.cs
+++ b/LitePlacer/MainForm.Designer.cs
@@ -30,7 +30,7 @@
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormMain));
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
             this.Park_button = new System.Windows.Forms.Button();
             this.TestNozzleRecognition_button = new System.Windows.Forms.Button();
             this.DownCamZoomFactor_textBox = new System.Windows.Forms.TextBox();
@@ -431,6 +431,7 @@
             this.ImageTest_checkBox = new System.Windows.Forms.CheckBox();
             this.Cam_pictureBox = new LitePlacer.Camera.ProtectedPictureBox();
             this.tabPageBasicSetup = new System.Windows.Forms.TabPage();
+            this.SlackCompensationDistance_textBox = new System.Windows.Forms.TextBox();
             this.Ato0_button = new System.Windows.Forms.Button();
             this.VacuumInvert_checkBox = new System.Windows.Forms.CheckBox();
             this.PumpInvert_checkBox = new System.Windows.Forms.CheckBox();
@@ -919,7 +920,7 @@
             // 
             this.DownCamZoomFactor_textBox.Location = new System.Drawing.Point(542, 694);
             this.DownCamZoomFactor_textBox.Name = "DownCamZoomFactor_textBox";
-            this.DownCamZoomFactor_textBox.Size = new System.Drawing.Size(38, 22);
+            this.DownCamZoomFactor_textBox.Size = new System.Drawing.Size(38, 20);
             this.DownCamZoomFactor_textBox.TabIndex = 57;
             this.DownCamZoomFactor_textBox.Text = "1.0";
             this.DownCamZoomFactor_textBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
@@ -932,7 +933,7 @@
             this.DownCamZoom_checkBox.AutoSize = true;
             this.DownCamZoom_checkBox.Location = new System.Drawing.Point(444, 673);
             this.DownCamZoom_checkBox.Name = "DownCamZoom_checkBox";
-            this.DownCamZoom_checkBox.Size = new System.Drawing.Size(131, 21);
+            this.DownCamZoom_checkBox.Size = new System.Drawing.Size(104, 17);
             this.DownCamZoom_checkBox.TabIndex = 56;
             this.DownCamZoom_checkBox.Text = "Downcam Zoom";
             this.toolTip1.SetToolTip(this.DownCamZoom_checkBox, "Digital zoom for Downcam image");
@@ -957,7 +958,7 @@
             // 
             this.textBoxSendtoTinyG.Location = new System.Drawing.Point(684, 831);
             this.textBoxSendtoTinyG.Name = "textBoxSendtoTinyG";
-            this.textBoxSendtoTinyG.Size = new System.Drawing.Size(241, 22);
+            this.textBoxSendtoTinyG.Size = new System.Drawing.Size(241, 20);
             this.textBoxSendtoTinyG.TabIndex = 8;
             this.toolTip1.SetToolTip(this.textBoxSendtoTinyG, "On enter, the text is sent directly to TinyG.");
             this.textBoxSendtoTinyG.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.textBoxSendtoTinyG_KeyPress);
@@ -967,7 +968,7 @@
             this.label4.AutoSize = true;
             this.label4.Location = new System.Drawing.Point(614, 834);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(90, 17);
+            this.label4.Size = new System.Drawing.Size(69, 13);
             this.label4.TabIndex = 7;
             this.label4.Text = "Text to send:";
             // 
@@ -977,7 +978,7 @@
             this.label14.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.944F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label14.Location = new System.Drawing.Point(611, 665);
             this.label14.Name = "label14";
-            this.label14.Size = new System.Drawing.Size(31, 24);
+            this.label14.Size = new System.Drawing.Size(24, 18);
             this.label14.TabIndex = 7;
             this.label14.Text = "X:";
             // 
@@ -989,7 +990,7 @@
             this.xpos_textBox.Name = "xpos_textBox";
             this.xpos_textBox.ReadOnly = true;
             this.xpos_textBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.xpos_textBox.Size = new System.Drawing.Size(113, 21);
+            this.xpos_textBox.Size = new System.Drawing.Size(113, 17);
             this.xpos_textBox.TabIndex = 9;
             this.xpos_textBox.Text = "- - - -";
             this.xpos_textBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
@@ -1003,7 +1004,7 @@
             this.ypos_textBox.Name = "ypos_textBox";
             this.ypos_textBox.ReadOnly = true;
             this.ypos_textBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.ypos_textBox.Size = new System.Drawing.Size(113, 21);
+            this.ypos_textBox.Size = new System.Drawing.Size(113, 17);
             this.ypos_textBox.TabIndex = 11;
             this.ypos_textBox.Text = "- - - -";
             this.ypos_textBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
@@ -1015,7 +1016,7 @@
             this.label17.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.944F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label17.Location = new System.Drawing.Point(611, 686);
             this.label17.Name = "label17";
-            this.label17.Size = new System.Drawing.Size(29, 24);
+            this.label17.Size = new System.Drawing.Size(23, 18);
             this.label17.TabIndex = 10;
             this.label17.Text = "Y:";
             // 
@@ -1027,7 +1028,7 @@
             this.zpos_textBox.Name = "zpos_textBox";
             this.zpos_textBox.ReadOnly = true;
             this.zpos_textBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.zpos_textBox.Size = new System.Drawing.Size(113, 21);
+            this.zpos_textBox.Size = new System.Drawing.Size(113, 17);
             this.zpos_textBox.TabIndex = 13;
             this.zpos_textBox.Text = "- - - -";
             this.zpos_textBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
@@ -1039,7 +1040,7 @@
             this.label18.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.944F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label18.Location = new System.Drawing.Point(611, 707);
             this.label18.Name = "label18";
-            this.label18.Size = new System.Drawing.Size(29, 24);
+            this.label18.Size = new System.Drawing.Size(23, 18);
             this.label18.TabIndex = 12;
             this.label18.Text = "Z:";
             // 
@@ -1051,7 +1052,7 @@
             this.apos_textBox.Name = "apos_textBox";
             this.apos_textBox.ReadOnly = true;
             this.apos_textBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.apos_textBox.Size = new System.Drawing.Size(113, 21);
+            this.apos_textBox.Size = new System.Drawing.Size(113, 17);
             this.apos_textBox.TabIndex = 15;
             this.apos_textBox.Text = "- - - -";
             this.apos_textBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
@@ -1064,7 +1065,7 @@
             this.label19.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.944F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label19.Location = new System.Drawing.Point(611, 728);
             this.label19.Name = "label19";
-            this.label19.Size = new System.Drawing.Size(30, 24);
+            this.label19.Size = new System.Drawing.Size(23, 18);
             this.label19.TabIndex = 14;
             this.label19.Text = "A:";
             // 
@@ -1130,7 +1131,7 @@
             // 
             this.UpCamZoomFactor_textBox.Location = new System.Drawing.Point(542, 747);
             this.UpCamZoomFactor_textBox.Name = "UpCamZoomFactor_textBox";
-            this.UpCamZoomFactor_textBox.Size = new System.Drawing.Size(38, 22);
+            this.UpCamZoomFactor_textBox.Size = new System.Drawing.Size(38, 20);
             this.UpCamZoomFactor_textBox.TabIndex = 59;
             this.UpCamZoomFactor_textBox.Text = "1.0";
             this.UpCamZoomFactor_textBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
@@ -1143,7 +1144,7 @@
             this.UpCamZoom_checkBox.AutoSize = true;
             this.UpCamZoom_checkBox.Location = new System.Drawing.Point(444, 723);
             this.UpCamZoom_checkBox.Name = "UpCamZoom_checkBox";
-            this.UpCamZoom_checkBox.Size = new System.Drawing.Size(114, 21);
+            this.UpCamZoom_checkBox.Size = new System.Drawing.Size(90, 17);
             this.UpCamZoom_checkBox.TabIndex = 58;
             this.UpCamZoom_checkBox.Text = "Upcam Zoom";
             this.toolTip1.SetToolTip(this.UpCamZoom_checkBox, "Digital zoom for Upcam image");
@@ -1290,10 +1291,10 @@
             this.Tapes_tabPage.Controls.Add(this.label109);
             this.Tapes_tabPage.Controls.Add(this.Tapes_dataGridView);
             this.Tapes_tabPage.Controls.Add(this.Tapes_pictureBox);
-            this.Tapes_tabPage.Location = new System.Drawing.Point(4, 25);
+            this.Tapes_tabPage.Location = new System.Drawing.Point(4, 22);
             this.Tapes_tabPage.Name = "Tapes_tabPage";
             this.Tapes_tabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.Tapes_tabPage.Size = new System.Drawing.Size(1245, 632);
+            this.Tapes_tabPage.Size = new System.Drawing.Size(1245, 635);
             this.Tapes_tabPage.TabIndex = 6;
             this.Tapes_tabPage.Text = "Tape Positions";
             this.Tapes_tabPage.UseVisualStyleBackColor = true;
@@ -1303,7 +1304,7 @@
             this.label158.AutoSize = true;
             this.label158.Location = new System.Drawing.Point(1152, 431);
             this.label158.Name = "label158";
-            this.label158.Size = new System.Drawing.Size(100, 17);
+            this.label158.Size = new System.Drawing.Size(77, 13);
             this.label158.TabIndex = 95;
             this.label158.Text = "Selected rows:";
             // 
@@ -1312,7 +1313,7 @@
             this.label157.AutoSize = true;
             this.label157.Location = new System.Drawing.Point(1149, 349);
             this.label157.Name = "label157";
-            this.label157.Size = new System.Drawing.Size(60, 17);
+            this.label157.Size = new System.Drawing.Size(46, 13);
             this.label157.TabIndex = 94;
             this.label157.Text = "All rows:";
             // 
@@ -1389,13 +1390,13 @@
             this.SelectButtonColumn.HeaderText = "Select";
             this.SelectButtonColumn.Name = "SelectButtonColumn";
             this.SelectButtonColumn.Text = "Reset";
-            this.SelectButtonColumn.Width = 53;
+            this.SelectButtonColumn.Width = 43;
             // 
             // IdColumn
             // 
             this.IdColumn.HeaderText = "ID";
             this.IdColumn.Name = "IdColumn";
-            this.IdColumn.Width = 50;
+            this.IdColumn.Width = 43;
             // 
             // OrientationColumn
             // 
@@ -1408,7 +1409,7 @@
             this.OrientationColumn.Name = "OrientationColumn";
             this.OrientationColumn.Resizable = System.Windows.Forms.DataGridViewTriState.False;
             this.OrientationColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.OrientationColumn.Width = 59;
+            this.OrientationColumn.Width = 48;
             // 
             // RotationColumn
             // 
@@ -1421,19 +1422,19 @@
             this.RotationColumn.Name = "RotationColumn";
             this.RotationColumn.Resizable = System.Windows.Forms.DataGridViewTriState.True;
             this.RotationColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.RotationColumn.Width = 63;
+            this.RotationColumn.Width = 52;
             // 
             // NozzleColumn
             // 
             this.NozzleColumn.HeaderText = "Nozzle";
             this.NozzleColumn.Name = "NozzleColumn";
-            this.NozzleColumn.Width = 80;
+            this.NozzleColumn.Width = 64;
             // 
             // WidthColumn
             // 
             this.WidthColumn.HeaderText = "Width";
             this.WidthColumn.Name = "WidthColumn";
-            this.WidthColumn.Width = 73;
+            this.WidthColumn.Width = 60;
             // 
             // CapacityColumn
             // 
@@ -1450,59 +1451,59 @@
             "Black Plastic",
             "Clear Plastic"});
             this.TypeColumn.Name = "TypeColumn";
-            this.TypeColumn.Width = 46;
+            this.TypeColumn.Width = 37;
             // 
             // Tray_Column
             // 
             this.Tray_Column.HeaderText = "Tray";
             this.Tray_Column.Name = "Tray_Column";
-            this.Tray_Column.Width = 66;
+            this.Tray_Column.Width = 53;
             // 
             // Next_Column
             // 
             this.Next_Column.HeaderText = "Next";
             this.Next_Column.Name = "Next_Column";
-            this.Next_Column.Width = 65;
+            this.Next_Column.Width = 54;
             // 
             // X_Column
             // 
             this.X_Column.HeaderText = "X";
             this.X_Column.Name = "X_Column";
             this.X_Column.ReadOnly = true;
-            this.X_Column.Width = 46;
+            this.X_Column.Width = 39;
             // 
             // Y_Column
             // 
             this.Y_Column.HeaderText = "Y";
             this.Y_Column.Name = "Y_Column";
             this.Y_Column.ReadOnly = true;
-            this.Y_Column.Width = 46;
+            this.Y_Column.Width = 39;
             // 
             // PickupZ_Column
             // 
             this.PickupZ_Column.HeaderText = "Pickup Z";
             this.PickupZ_Column.Name = "PickupZ_Column";
-            this.PickupZ_Column.Width = 92;
+            this.PickupZ_Column.Width = 75;
             // 
             // PlaceZ_Column
             // 
             this.PlaceZ_Column.HeaderText = "PlaceZ";
             this.PlaceZ_Column.Name = "PlaceZ_Column";
-            this.PlaceZ_Column.Width = 81;
+            this.PlaceZ_Column.Width = 66;
             // 
             // NextX_Column
             // 
             this.NextX_Column.HeaderText = "Next X";
             this.NextX_Column.Name = "NextX_Column";
             this.NextX_Column.ReadOnly = true;
-            this.NextX_Column.Width = 78;
+            this.NextX_Column.Width = 64;
             // 
             // NextY_column
             // 
             this.NextY_column.HeaderText = "Next Y";
             this.NextY_column.Name = "NextY_column";
             this.NextY_column.ReadOnly = true;
-            this.NextY_column.Width = 78;
+            this.NextY_column.Width = 64;
             // 
             // Tapes_contextMenuStrip
             // 
@@ -1510,12 +1511,12 @@
             this.Tapes_contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.editToolStripMenuItem});
             this.Tapes_contextMenuStrip.Name = "Tapes_contextMenuStrip";
-            this.Tapes_contextMenuStrip.Size = new System.Drawing.Size(105, 28);
+            this.Tapes_contextMenuStrip.Size = new System.Drawing.Size(95, 26);
             // 
             // editToolStripMenuItem
             // 
             this.editToolStripMenuItem.Name = "editToolStripMenuItem";
-            this.editToolStripMenuItem.Size = new System.Drawing.Size(104, 24);
+            this.editToolStripMenuItem.Size = new System.Drawing.Size(94, 22);
             this.editToolStripMenuItem.Text = "Edit";
             this.editToolStripMenuItem.Click += new System.EventHandler(this.EditTape_MenuItemClick);
             // 
@@ -1537,7 +1538,7 @@
             this.label129.AutoSize = true;
             this.label129.Location = new System.Drawing.Point(391, 500);
             this.label129.Name = "label129";
-            this.label129.Size = new System.Drawing.Size(101, 17);
+            this.label129.Size = new System.Drawing.Size(76, 13);
             this.label129.TabIndex = 51;
             this.label129.Text = "Alignment test:";
             // 
@@ -1557,7 +1558,7 @@
             this.label128.AutoSize = true;
             this.label128.Location = new System.Drawing.Point(392, 519);
             this.label128.Name = "label128";
-            this.label128.Size = new System.Drawing.Size(50, 17);
+            this.label128.Size = new System.Drawing.Size(39, 13);
             this.label128.TabIndex = 49;
             this.label128.Text = "Part #:";
             // 
@@ -1568,7 +1569,7 @@
             this.HoleTest_maskedTextBox.Name = "HoleTest_maskedTextBox";
             this.HoleTest_maskedTextBox.PromptChar = ' ';
             this.HoleTest_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.HoleTest_maskedTextBox.Size = new System.Drawing.Size(32, 22);
+            this.HoleTest_maskedTextBox.Size = new System.Drawing.Size(32, 20);
             this.HoleTest_maskedTextBox.TabIndex = 48;
             this.HoleTest_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.HoleTest_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -1671,7 +1672,7 @@
             this.label67.AutoSize = true;
             this.label67.Location = new System.Drawing.Point(1152, 325);
             this.label67.Name = "label67";
-            this.label67.Size = new System.Drawing.Size(50, 17);
+            this.label67.Size = new System.Drawing.Size(39, 13);
             this.label67.TabIndex = 37;
             this.label67.Text = "Part #:";
             // 
@@ -1680,7 +1681,7 @@
             this.label62.AutoSize = true;
             this.label62.Location = new System.Drawing.Point(1161, 306);
             this.label62.Name = "label62";
-            this.label62.Size = new System.Drawing.Size(88, 17);
+            this.label62.Size = new System.Drawing.Size(66, 13);
             this.label62.TabIndex = 36;
             this.label62.Text = "for next part.";
             // 
@@ -1701,7 +1702,7 @@
             this.NextPart_TextBox.Name = "NextPart_TextBox";
             this.NextPart_TextBox.PromptChar = ' ';
             this.NextPart_TextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.NextPart_TextBox.Size = new System.Drawing.Size(32, 22);
+            this.NextPart_TextBox.Size = new System.Drawing.Size(32, 20);
             this.NextPart_TextBox.TabIndex = 34;
             this.NextPart_TextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.NextPart_TextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -1766,7 +1767,7 @@
             this.label109.AutoSize = true;
             this.label109.Location = new System.Drawing.Point(649, 3);
             this.label109.Name = "label109";
-            this.label109.Size = new System.Drawing.Size(75, 17);
+            this.label109.Size = new System.Drawing.Size(58, 13);
             this.label109.TabIndex = 16;
             this.label109.Text = "Tape Data";
             // 
@@ -1822,19 +1823,19 @@
             this.SelectButton_Column.HeaderText = "Select";
             this.SelectButton_Column.Name = "SelectButton_Column";
             this.SelectButton_Column.Text = "Reset";
-            this.SelectButton_Column.Width = 53;
+            this.SelectButton_Column.Width = 43;
             // 
             // Id_Column
             // 
             this.Id_Column.HeaderText = "ID";
             this.Id_Column.Name = "Id_Column";
-            this.Id_Column.Width = 50;
+            this.Id_Column.Width = 43;
             // 
             // NextPart_Column
             // 
             this.NextPart_Column.HeaderText = "Next";
             this.NextPart_Column.Name = "NextPart_Column";
-            this.NextPart_Column.Width = 65;
+            this.NextPart_Column.Width = 54;
             // 
             // Orientation_Column
             // 
@@ -1847,13 +1848,13 @@
             this.Orientation_Column.Name = "Orientation_Column";
             this.Orientation_Column.Resizable = System.Windows.Forms.DataGridViewTriState.False;
             this.Orientation_Column.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.Orientation_Column.Width = 59;
+            this.Orientation_Column.Width = 48;
             // 
             // Nozzle_Column
             // 
             this.Nozzle_Column.HeaderText = "Nozzle";
             this.Nozzle_Column.Name = "Nozzle_Column";
-            this.Nozzle_Column.Width = 80;
+            this.Nozzle_Column.Width = 64;
             // 
             // Capacity_Column
             // 
@@ -1866,7 +1867,7 @@
             // 
             this.TrayID_Column.HeaderText = "Tray";
             this.TrayID_Column.Name = "TrayID_Column";
-            this.TrayID_Column.Width = 66;
+            this.TrayID_Column.Width = 53;
             // 
             // Rotation_Column
             // 
@@ -1879,7 +1880,7 @@
             this.Rotation_Column.Name = "Rotation_Column";
             this.Rotation_Column.Resizable = System.Windows.Forms.DataGridViewTriState.True;
             this.Rotation_Column.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.Rotation_Column.Width = 63;
+            this.Rotation_Column.Width = 52;
             // 
             // Type_Column
             // 
@@ -1889,7 +1890,7 @@
             "Black Plastic",
             "Clear Plastic"});
             this.Type_Column.Name = "Type_Column";
-            this.Type_Column.Width = 46;
+            this.Type_Column.Width = 37;
             // 
             // Width_Column
             // 
@@ -1917,89 +1918,89 @@
             "32/32mm",
             "custom"});
             this.Width_Column.Name = "Width_Column";
-            this.Width_Column.Width = 50;
+            this.Width_Column.Width = 41;
             // 
             // Pitch_Column
             // 
             this.Pitch_Column.HeaderText = "Pitch";
             this.Pitch_Column.Name = "Pitch_Column";
-            this.Pitch_Column.Width = 68;
+            this.Pitch_Column.Width = 56;
             // 
             // OffsetX_Column
             // 
             this.OffsetX_Column.HeaderText = "Offset X";
             this.OffsetX_Column.Name = "OffsetX_Column";
-            this.OffsetX_Column.Width = 82;
+            this.OffsetX_Column.Width = 65;
             // 
             // OffsetY_Column
             // 
             this.OffsetY_Column.HeaderText = "Offset Y";
             this.OffsetY_Column.Name = "OffsetY_Column";
-            this.OffsetY_Column.Width = 82;
+            this.OffsetY_Column.Width = 65;
             // 
             // FirstX_Column
             // 
             this.FirstX_Column.HeaderText = "X";
             this.FirstX_Column.Name = "FirstX_Column";
             this.FirstX_Column.ReadOnly = true;
-            this.FirstX_Column.Width = 46;
+            this.FirstX_Column.Width = 39;
             // 
             // FirstY_Column
             // 
             this.FirstY_Column.HeaderText = "Y";
             this.FirstY_Column.Name = "FirstY_Column";
             this.FirstY_Column.ReadOnly = true;
-            this.FirstY_Column.Width = 46;
+            this.FirstY_Column.Width = 39;
             // 
             // Z_Pickup_Column
             // 
             this.Z_Pickup_Column.HeaderText = "Pickup Z";
             this.Z_Pickup_Column.Name = "Z_Pickup_Column";
-            this.Z_Pickup_Column.Width = 85;
+            this.Z_Pickup_Column.Width = 69;
             // 
             // Z_Place_Column
             // 
             this.Z_Place_Column.HeaderText = "Place Z";
             this.Z_Place_Column.Name = "Z_Place_Column";
-            this.Z_Place_Column.Width = 79;
+            this.Z_Place_Column.Width = 64;
             // 
             // Next_X_Column
             // 
             this.Next_X_Column.HeaderText = "Next X";
             this.Next_X_Column.Name = "Next_X_Column";
             this.Next_X_Column.ReadOnly = true;
-            this.Next_X_Column.Width = 73;
+            this.Next_X_Column.Width = 60;
             // 
             // Next_Y_Column
             // 
             this.Next_Y_Column.HeaderText = "Next Y";
             this.Next_Y_Column.Name = "Next_Y_Column";
             this.Next_Y_Column.ReadOnly = true;
-            this.Next_Y_Column.Width = 73;
+            this.Next_Y_Column.Width = 60;
             // 
             // CoordinatesForParts_Column
             // 
             this.CoordinatesForParts_Column.HeaderText = "Coordinates for parts";
             this.CoordinatesForParts_Column.Name = "CoordinatesForParts_Column";
-            this.CoordinatesForParts_Column.Width = 104;
+            this.CoordinatesForParts_Column.Width = 78;
             // 
             // LastX_Column
             // 
             this.LastX_Column.HeaderText = "Last X";
             this.LastX_Column.Name = "LastX_Column";
-            this.LastX_Column.Width = 64;
+            this.LastX_Column.Width = 58;
             // 
             // LastY_column
             // 
             this.LastY_column.HeaderText = "Last Y";
             this.LastY_column.Name = "LastY_column";
-            this.LastY_column.Width = 64;
+            this.LastY_column.Width = 58;
             // 
             // RotationDirect_Column
             // 
             this.RotationDirect_Column.HeaderText = "Rotation";
             this.RotationDirect_Column.Name = "RotationDirect_Column";
-            this.RotationDirect_Column.Width = 90;
+            this.RotationDirect_Column.Width = 72;
             // 
             // Tapes_pictureBox
             // 
@@ -2015,10 +2016,10 @@
             // Components_tabPage
             // 
             this.Components_tabPage.Controls.Add(this.ComponentData_dataGridView);
-            this.Components_tabPage.Location = new System.Drawing.Point(4, 25);
+            this.Components_tabPage.Location = new System.Drawing.Point(4, 22);
             this.Components_tabPage.Name = "Components_tabPage";
             this.Components_tabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.Components_tabPage.Size = new System.Drawing.Size(1245, 632);
+            this.Components_tabPage.Size = new System.Drawing.Size(1245, 635);
             this.Components_tabPage.TabIndex = 3;
             this.Components_tabPage.Text = "Component Data";
             this.Components_tabPage.UseVisualStyleBackColor = true;
@@ -2097,10 +2098,10 @@
             this.tabPageSetupCameras.Controls.Add(this.label94);
             this.tabPageSetupCameras.Controls.Add(this.ImageTest_checkBox);
             this.tabPageSetupCameras.Controls.Add(this.Cam_pictureBox);
-            this.tabPageSetupCameras.Location = new System.Drawing.Point(4, 25);
+            this.tabPageSetupCameras.Location = new System.Drawing.Point(4, 22);
             this.tabPageSetupCameras.Name = "tabPageSetupCameras";
             this.tabPageSetupCameras.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPageSetupCameras.Size = new System.Drawing.Size(1245, 632);
+            this.tabPageSetupCameras.Size = new System.Drawing.Size(1245, 635);
             this.tabPageSetupCameras.TabIndex = 0;
             this.tabPageSetupCameras.Text = "Setup Cameras";
             this.tabPageSetupCameras.UseVisualStyleBackColor = true;
@@ -2113,7 +2114,7 @@
             this.NozzleOffset_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.NozzleOffset_label.Location = new System.Drawing.Point(9, 553);
             this.NozzleOffset_label.Name = "NozzleOffset_label";
-            this.NozzleOffset_label.Size = new System.Drawing.Size(150, 26);
+            this.NozzleOffset_label.Size = new System.Drawing.Size(119, 20);
             this.NozzleOffset_label.TabIndex = 50;
             this.NozzleOffset_label.Text = "Instructions here";
             // 
@@ -2410,9 +2411,9 @@
             this.DownCamera_tabPage.Controls.Add(this.AddCamFunction_button);
             this.DownCamera_tabPage.Controls.Add(this.Display_dataGridView);
             this.DownCamera_tabPage.Controls.Add(this.groupBox4);
-            this.DownCamera_tabPage.Location = new System.Drawing.Point(4, 25);
+            this.DownCamera_tabPage.Location = new System.Drawing.Point(4, 22);
             this.DownCamera_tabPage.Name = "DownCamera_tabPage";
-            this.DownCamera_tabPage.Size = new System.Drawing.Size(579, 591);
+            this.DownCamera_tabPage.Size = new System.Drawing.Size(579, 594);
             this.DownCamera_tabPage.TabIndex = 3;
             this.DownCamera_tabPage.Text = "Down Looking Camera";
             this.DownCamera_tabPage.UseVisualStyleBackColor = true;
@@ -2423,7 +2424,7 @@
             this.CamShowPixels_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.CamShowPixels_checkBox.Location = new System.Drawing.Point(6, 52);
             this.CamShowPixels_checkBox.Name = "CamShowPixels_checkBox";
-            this.CamShowPixels_checkBox.Size = new System.Drawing.Size(95, 19);
+            this.CamShowPixels_checkBox.Size = new System.Drawing.Size(82, 17);
             this.CamShowPixels_checkBox.TabIndex = 156;
             this.CamShowPixels_checkBox.Text = "Show pixels";
             this.toolTip1.SetToolTip(this.CamShowPixels_checkBox, "This draws camera image mapped 1:1 to pixels \r\non the screen. With high resolutio" +
@@ -2438,7 +2439,7 @@
             this.label46.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label46.Location = new System.Drawing.Point(292, 76);
             this.label46.Name = "label46";
-            this.label46.Size = new System.Drawing.Size(56, 15);
+            this.label46.Size = new System.Drawing.Size(49, 13);
             this.label46.TabIndex = 153;
             this.label46.Text = "Box size:";
             this.toolTip1.SetToolTip(this.label46, "Set the true size of the box on the image.");
@@ -2449,7 +2450,7 @@
             this.DownCameraBoxYmmPerPixel_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.DownCameraBoxYmmPerPixel_label.Location = new System.Drawing.Point(396, 121);
             this.DownCameraBoxYmmPerPixel_label.Name = "DownCameraBoxYmmPerPixel_label";
-            this.DownCameraBoxYmmPerPixel_label.Size = new System.Drawing.Size(19, 15);
+            this.DownCameraBoxYmmPerPixel_label.Size = new System.Drawing.Size(16, 13);
             this.DownCameraBoxYmmPerPixel_label.TabIndex = 27;
             this.DownCameraBoxYmmPerPixel_label.Text = "---";
             this.toolTip1.SetToolTip(this.DownCameraBoxYmmPerPixel_label, "Set the true size of the box on the image.");
@@ -2472,7 +2473,7 @@
             this.label71.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label71.Location = new System.Drawing.Point(367, 121);
             this.label71.Name = "label71";
-            this.label71.Size = new System.Drawing.Size(29, 15);
+            this.label71.Size = new System.Drawing.Size(23, 13);
             this.label71.TabIndex = 23;
             this.label71.Text = "mm";
             this.toolTip1.SetToolTip(this.label71, "Set the true size of the box on the image.");
@@ -2483,7 +2484,7 @@
             this.label35.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label35.Location = new System.Drawing.Point(471, 76);
             this.label35.Name = "label35";
-            this.label35.Size = new System.Drawing.Size(115, 15);
+            this.label35.Size = new System.Drawing.Size(98, 13);
             this.label35.TabIndex = 152;
             this.label35.Text = "Desired Resolution:";
             this.toolTip1.SetToolTip(this.label35, "Set the native camera resolution here");
@@ -2494,7 +2495,7 @@
             this.label68.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label68.Location = new System.Drawing.Point(292, 95);
             this.label68.Name = "label68";
-            this.label68.Size = new System.Drawing.Size(18, 15);
+            this.label68.Size = new System.Drawing.Size(17, 13);
             this.label68.TabIndex = 18;
             this.label68.Text = "X:";
             this.toolTip1.SetToolTip(this.label68, "Set the true size of the box on the image.");
@@ -2505,7 +2506,7 @@
             this.label12.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label12.Location = new System.Drawing.Point(503, 95);
             this.label12.Name = "label12";
-            this.label12.Size = new System.Drawing.Size(18, 15);
+            this.label12.Size = new System.Drawing.Size(17, 13);
             this.label12.TabIndex = 148;
             this.label12.Text = "X:";
             this.toolTip1.SetToolTip(this.label12, "Set the native camera resolution here");
@@ -2516,7 +2517,7 @@
             this.label69.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label69.Location = new System.Drawing.Point(292, 121);
             this.label69.Name = "label69";
-            this.label69.Size = new System.Drawing.Size(17, 15);
+            this.label69.Size = new System.Drawing.Size(17, 13);
             this.label69.TabIndex = 19;
             this.label69.Text = "Y:";
             this.toolTip1.SetToolTip(this.label69, "Set the true size of the box on the image.");
@@ -2527,7 +2528,7 @@
             this.label24.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label24.Location = new System.Drawing.Point(503, 120);
             this.label24.Name = "label24";
-            this.label24.Size = new System.Drawing.Size(17, 15);
+            this.label24.Size = new System.Drawing.Size(17, 13);
             this.label24.TabIndex = 149;
             this.label24.Text = "Y:";
             this.toolTip1.SetToolTip(this.label24, "Set the native camera resolution here");
@@ -2538,7 +2539,7 @@
             this.DownCameraBoxXmmPerPixel_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.DownCameraBoxXmmPerPixel_label.Location = new System.Drawing.Point(396, 95);
             this.DownCameraBoxXmmPerPixel_label.Name = "DownCameraBoxXmmPerPixel_label";
-            this.DownCameraBoxXmmPerPixel_label.Size = new System.Drawing.Size(19, 15);
+            this.DownCameraBoxXmmPerPixel_label.Size = new System.Drawing.Size(16, 13);
             this.DownCameraBoxXmmPerPixel_label.TabIndex = 26;
             this.DownCameraBoxXmmPerPixel_label.Text = "---";
             this.toolTip1.SetToolTip(this.DownCameraBoxXmmPerPixel_label, "Set the true size of the box on the image.");
@@ -2548,7 +2549,7 @@
             this.DownCameraDesiredX_textBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.DownCameraDesiredX_textBox.Location = new System.Drawing.Point(523, 92);
             this.DownCameraDesiredX_textBox.Name = "DownCameraDesiredX_textBox";
-            this.DownCameraDesiredX_textBox.Size = new System.Drawing.Size(46, 21);
+            this.DownCameraDesiredX_textBox.Size = new System.Drawing.Size(46, 18);
             this.DownCameraDesiredX_textBox.TabIndex = 150;
             this.toolTip1.SetToolTip(this.DownCameraDesiredX_textBox, "Set the native camera resolution here");
             this.DownCameraDesiredX_textBox.TextChanged += new System.EventHandler(this.DownCameraDesiredX_textBox_TextChanged);
@@ -2558,7 +2559,7 @@
             this.DownCameraDesiredY_textBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.DownCameraDesiredY_textBox.Location = new System.Drawing.Point(523, 116);
             this.DownCameraDesiredY_textBox.Name = "DownCameraDesiredY_textBox";
-            this.DownCameraDesiredY_textBox.Size = new System.Drawing.Size(46, 21);
+            this.DownCameraDesiredY_textBox.Size = new System.Drawing.Size(46, 18);
             this.DownCameraDesiredY_textBox.TabIndex = 151;
             this.toolTip1.SetToolTip(this.DownCameraDesiredY_textBox, "Set the native camera resolution here");
             this.DownCameraDesiredY_textBox.TextChanged += new System.EventHandler(this.DownCameraDesiredY_textBox_TextChanged);
@@ -2604,7 +2605,7 @@
             this.label135.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label135.Location = new System.Drawing.Point(98, 38);
             this.label135.Name = "label135";
-            this.label135.Size = new System.Drawing.Size(91, 15);
+            this.label135.Size = new System.Drawing.Size(78, 13);
             this.label135.TabIndex = 143;
             this.label135.Text = "Camera switch:";
             this.toolTip1.SetToolTip(this.label135, resources.GetString("label135.ToolTip"));
@@ -2614,7 +2615,7 @@
             this.DownCameraBoxX_textBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.DownCameraBoxX_textBox.Location = new System.Drawing.Point(315, 92);
             this.DownCameraBoxX_textBox.Name = "DownCameraBoxX_textBox";
-            this.DownCameraBoxX_textBox.Size = new System.Drawing.Size(46, 21);
+            this.DownCameraBoxX_textBox.Size = new System.Drawing.Size(46, 18);
             this.DownCameraBoxX_textBox.TabIndex = 20;
             this.toolTip1.SetToolTip(this.DownCameraBoxX_textBox, "Set the true size of the box on the image.");
             this.DownCameraBoxX_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.DownCameraBoxX_textBox_KeyPress);
@@ -2626,7 +2627,7 @@
             this.KeepActive_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.KeepActive_checkBox.Location = new System.Drawing.Point(351, 37);
             this.KeepActive_checkBox.Name = "KeepActive_checkBox";
-            this.KeepActive_checkBox.Size = new System.Drawing.Size(92, 19);
+            this.KeepActive_checkBox.Size = new System.Drawing.Size(83, 17);
             this.KeepActive_checkBox.TabIndex = 142;
             this.KeepActive_checkBox.Text = "Keep Active";
             this.toolTip1.SetToolTip(this.KeepActive_checkBox, resources.GetString("KeepActive_checkBox.ToolTip"));
@@ -2638,7 +2639,7 @@
             this.DowncamSnapshot_ColorBox.Location = new System.Drawing.Point(152, 327);
             this.DowncamSnapshot_ColorBox.Name = "DowncamSnapshot_ColorBox";
             this.DowncamSnapshot_ColorBox.ReadOnly = true;
-            this.DowncamSnapshot_ColorBox.Size = new System.Drawing.Size(21, 22);
+            this.DowncamSnapshot_ColorBox.Size = new System.Drawing.Size(21, 20);
             this.DowncamSnapshot_ColorBox.TabIndex = 141;
             this.toolTip1.SetToolTip(this.DowncamSnapshot_ColorBox, "Set parameters for the selected algorithm");
             this.DowncamSnapshot_ColorBox.Visible = false;
@@ -2650,7 +2651,7 @@
             this.label70.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label70.Location = new System.Drawing.Point(367, 95);
             this.label70.Name = "label70";
-            this.label70.Size = new System.Drawing.Size(29, 15);
+            this.label70.Size = new System.Drawing.Size(23, 13);
             this.label70.TabIndex = 22;
             this.label70.Text = "mm";
             this.toolTip1.SetToolTip(this.label70, "Set the true size of the box on the image.");
@@ -2783,7 +2784,7 @@
             this.RobustFast_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.RobustFast_checkBox.Location = new System.Drawing.Point(195, 37);
             this.RobustFast_checkBox.Name = "RobustFast_checkBox";
-            this.RobustFast_checkBox.Size = new System.Drawing.Size(150, 19);
+            this.RobustFast_checkBox.Size = new System.Drawing.Size(130, 17);
             this.RobustFast_checkBox.TabIndex = 140;
             this.RobustFast_checkBox.Text = "Robust (uncheck: fast)";
             this.toolTip1.SetToolTip(this.RobustFast_checkBox, resources.GetString("RobustFast_checkBox.ToolTip"));
@@ -2795,7 +2796,7 @@
             this.DownCameraBoxY_textBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.DownCameraBoxY_textBox.Location = new System.Drawing.Point(315, 118);
             this.DownCameraBoxY_textBox.Name = "DownCameraBoxY_textBox";
-            this.DownCameraBoxY_textBox.Size = new System.Drawing.Size(46, 21);
+            this.DownCameraBoxY_textBox.Size = new System.Drawing.Size(46, 18);
             this.DownCameraBoxY_textBox.TabIndex = 21;
             this.toolTip1.SetToolTip(this.DownCameraBoxY_textBox, "Set the true size of the box on the image.");
             this.DownCameraBoxY_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.DownCameraBoxY_textBox_KeyPress);
@@ -2807,7 +2808,7 @@
             this.DownCameraDrawTicks_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.DownCameraDrawTicks_checkBox.Location = new System.Drawing.Point(6, 96);
             this.DownCameraDrawTicks_checkBox.Name = "DownCameraDrawTicks_checkBox";
-            this.DownCameraDrawTicks_checkBox.Size = new System.Drawing.Size(117, 19);
+            this.DownCameraDrawTicks_checkBox.Size = new System.Drawing.Size(98, 17);
             this.DownCameraDrawTicks_checkBox.TabIndex = 139;
             this.DownCameraDrawTicks_checkBox.Text = "Draw Tickmarks";
             this.toolTip1.SetToolTip(this.DownCameraDrawTicks_checkBox, "Draws tickmarks on image side\r\ncorresponding to 10cm in workarea\r\n(cntrl-click mo" +
@@ -2942,7 +2943,7 @@
             this.ColorHelp_label.AutoSize = true;
             this.ColorHelp_label.Location = new System.Drawing.Point(282, 327);
             this.ColorHelp_label.Name = "ColorHelp_label";
-            this.ColorHelp_label.Size = new System.Drawing.Size(235, 17);
+            this.ColorHelp_label.Size = new System.Drawing.Size(176, 13);
             this.ColorHelp_label.TabIndex = 137;
             this.ColorHelp_label.Text = "(Alt+click to select color from image)";
             this.toolTip1.SetToolTip(this.ColorHelp_label, "Set parameters for the selected algorithm");
@@ -2956,7 +2957,7 @@
             0,
             0});
             this.B_numericUpDown.Name = "B_numericUpDown";
-            this.B_numericUpDown.Size = new System.Drawing.Size(46, 22);
+            this.B_numericUpDown.Size = new System.Drawing.Size(46, 20);
             this.B_numericUpDown.TabIndex = 136;
             this.toolTip1.SetToolTip(this.B_numericUpDown, "Set parameters for the selected algorithm");
             this.B_numericUpDown.Value = new decimal(new int[] {
@@ -2971,7 +2972,7 @@
             this.B_label.AutoSize = true;
             this.B_label.Location = new System.Drawing.Point(520, 287);
             this.B_label.Name = "B_label";
-            this.B_label.Size = new System.Drawing.Size(17, 17);
+            this.B_label.Size = new System.Drawing.Size(14, 13);
             this.B_label.TabIndex = 135;
             this.B_label.Text = "B";
             this.toolTip1.SetToolTip(this.B_label, "Set parameters for the selected algorithm");
@@ -2985,7 +2986,7 @@
             0,
             0});
             this.G_numericUpDown.Name = "G_numericUpDown";
-            this.G_numericUpDown.Size = new System.Drawing.Size(46, 22);
+            this.G_numericUpDown.Size = new System.Drawing.Size(46, 20);
             this.G_numericUpDown.TabIndex = 134;
             this.toolTip1.SetToolTip(this.G_numericUpDown, "Set parameters for the selected algorithm");
             this.G_numericUpDown.Value = new decimal(new int[] {
@@ -3000,7 +3001,7 @@
             this.G_label.AutoSize = true;
             this.G_label.Location = new System.Drawing.Point(448, 289);
             this.G_label.Name = "G_label";
-            this.G_label.Size = new System.Drawing.Size(19, 17);
+            this.G_label.Size = new System.Drawing.Size(15, 13);
             this.G_label.TabIndex = 133;
             this.G_label.Text = "G";
             this.toolTip1.SetToolTip(this.G_label, "Set parameters for the selected algorithm");
@@ -3014,7 +3015,7 @@
             0,
             0});
             this.R_numericUpDown.Name = "R_numericUpDown";
-            this.R_numericUpDown.Size = new System.Drawing.Size(46, 22);
+            this.R_numericUpDown.Size = new System.Drawing.Size(46, 20);
             this.R_numericUpDown.TabIndex = 132;
             this.toolTip1.SetToolTip(this.R_numericUpDown, "Set parameters for the selected algorithm");
             this.R_numericUpDown.Value = new decimal(new int[] {
@@ -3029,7 +3030,7 @@
             this.R_label.AutoSize = true;
             this.R_label.Location = new System.Drawing.Point(370, 288);
             this.R_label.Name = "R_label";
-            this.R_label.Size = new System.Drawing.Size(18, 17);
+            this.R_label.Size = new System.Drawing.Size(15, 13);
             this.R_label.TabIndex = 131;
             this.R_label.Text = "R";
             this.toolTip1.SetToolTip(this.R_label, "Set parameters for the selected algorithm");
@@ -3039,7 +3040,7 @@
             this.Color_label.AutoSize = true;
             this.Color_label.Location = new System.Drawing.Point(282, 289);
             this.Color_label.Name = "Color_label";
-            this.Color_label.Size = new System.Drawing.Size(81, 17);
+            this.Color_label.Size = new System.Drawing.Size(61, 13);
             this.Color_label.TabIndex = 130;
             this.Color_label.Text = "Color to kill:";
             this.toolTip1.SetToolTip(this.Color_label, "Set parameters for the selected algorithm");
@@ -3049,7 +3050,7 @@
             this.Color_Box.Location = new System.Drawing.Point(285, 304);
             this.Color_Box.Name = "Color_Box";
             this.Color_Box.ReadOnly = true;
-            this.Color_Box.Size = new System.Drawing.Size(21, 22);
+            this.Color_Box.Size = new System.Drawing.Size(21, 20);
             this.Color_Box.TabIndex = 129;
             this.toolTip1.SetToolTip(this.Color_Box, "Set parameters for the selected algorithm");
             // 
@@ -3326,7 +3327,7 @@
             this.Parameter_double_label.AutoSize = true;
             this.Parameter_double_label.Location = new System.Drawing.Point(171, 288);
             this.Parameter_double_label.Name = "Parameter_double_label";
-            this.Parameter_double_label.Size = new System.Drawing.Size(54, 17);
+            this.Parameter_double_label.Size = new System.Drawing.Size(41, 13);
             this.Parameter_double_label.TabIndex = 122;
             this.Parameter_double_label.Text = "label90";
             this.toolTip1.SetToolTip(this.Parameter_double_label, "Set parameters for the selected algorithm");
@@ -3337,7 +3338,7 @@
             this.DownCam_FindComponents_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.DownCam_FindComponents_checkBox.Location = new System.Drawing.Point(125, 96);
             this.DownCam_FindComponents_checkBox.Name = "DownCam_FindComponents_checkBox";
-            this.DownCam_FindComponents_checkBox.Size = new System.Drawing.Size(126, 19);
+            this.DownCam_FindComponents_checkBox.Size = new System.Drawing.Size(108, 17);
             this.DownCam_FindComponents_checkBox.TabIndex = 54;
             this.DownCam_FindComponents_checkBox.Text = "Find Components";
             this.toolTip1.SetToolTip(this.DownCam_FindComponents_checkBox, "Tries to find component shapes on the image,\r\nusing video processing from the tab" +
@@ -3349,7 +3350,7 @@
             // 
             this.Parameter_double_textBox.Location = new System.Drawing.Point(174, 304);
             this.Parameter_double_textBox.Name = "Parameter_double_textBox";
-            this.Parameter_double_textBox.Size = new System.Drawing.Size(38, 22);
+            this.Parameter_double_textBox.Size = new System.Drawing.Size(38, 20);
             this.Parameter_double_textBox.TabIndex = 121;
             this.Parameter_double_textBox.Text = "1.0";
             this.Parameter_double_textBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
@@ -3494,7 +3495,7 @@
             0,
             0});
             this.Parameter_Int_numericUpDown.Name = "Parameter_Int_numericUpDown";
-            this.Parameter_Int_numericUpDown.Size = new System.Drawing.Size(46, 22);
+            this.Parameter_Int_numericUpDown.Size = new System.Drawing.Size(46, 20);
             this.Parameter_Int_numericUpDown.TabIndex = 120;
             this.toolTip1.SetToolTip(this.Parameter_Int_numericUpDown, "Set parameters for the selected algorithm");
             this.Parameter_Int_numericUpDown.Value = new decimal(new int[] {
@@ -3511,7 +3512,7 @@
             this.DownCam_comboBox.FormattingEnabled = true;
             this.DownCam_comboBox.Location = new System.Drawing.Point(3, 8);
             this.DownCam_comboBox.Name = "DownCam_comboBox";
-            this.DownCam_comboBox.Size = new System.Drawing.Size(132, 23);
+            this.DownCam_comboBox.Size = new System.Drawing.Size(132, 21);
             this.DownCam_comboBox.TabIndex = 5;
             this.toolTip1.SetToolTip(this.DownCam_comboBox, "List of USB cameras found on this computer.\r\nSelect Down looking camera form this" +
         " list.");
@@ -3521,7 +3522,7 @@
             this.Parameter_int_label.AutoSize = true;
             this.Parameter_int_label.Location = new System.Drawing.Point(86, 287);
             this.Parameter_int_label.Name = "Parameter_int_label";
-            this.Parameter_int_label.Size = new System.Drawing.Size(45, 17);
+            this.Parameter_int_label.Size = new System.Drawing.Size(35, 13);
             this.Parameter_int_label.TabIndex = 119;
             this.Parameter_int_label.Text = "ParInt";
             this.toolTip1.SetToolTip(this.Parameter_int_label, "Set parameters for the selected algorithm");
@@ -3532,7 +3533,7 @@
             this.DownCamFindRectangles_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.DownCamFindRectangles_checkBox.Location = new System.Drawing.Point(125, 119);
             this.DownCamFindRectangles_checkBox.Name = "DownCamFindRectangles_checkBox";
-            this.DownCamFindRectangles_checkBox.Size = new System.Drawing.Size(118, 19);
+            this.DownCamFindRectangles_checkBox.Size = new System.Drawing.Size(101, 17);
             this.DownCamFindRectangles_checkBox.TabIndex = 53;
             this.DownCamFindRectangles_checkBox.Text = "Find Rectangles";
             this.toolTip1.SetToolTip(this.DownCamFindRectangles_checkBox, "Tries to find rectangels on the image,\r\nusing video processing from the table bel" +
@@ -3567,7 +3568,7 @@
             this.FiducialManConfirmation_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.FiducialManConfirmation_checkBox.Location = new System.Drawing.Point(89, 80);
             this.FiducialManConfirmation_checkBox.Name = "FiducialManConfirmation_checkBox";
-            this.FiducialManConfirmation_checkBox.Size = new System.Drawing.Size(142, 19);
+            this.FiducialManConfirmation_checkBox.Size = new System.Drawing.Size(120, 17);
             this.FiducialManConfirmation_checkBox.TabIndex = 148;
             this.FiducialManConfirmation_checkBox.Text = "Manual confirmation";
             this.FiducialManConfirmation_checkBox.UseVisualStyleBackColor = true;
@@ -3579,7 +3580,7 @@
             this.AutoFiducial_radioButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.AutoFiducial_radioButton.Location = new System.Drawing.Point(11, 94);
             this.AutoFiducial_radioButton.Name = "AutoFiducial_radioButton";
-            this.AutoFiducial_radioButton.Size = new System.Drawing.Size(53, 19);
+            this.AutoFiducial_radioButton.Size = new System.Drawing.Size(47, 17);
             this.AutoFiducial_radioButton.TabIndex = 133;
             this.AutoFiducial_radioButton.TabStop = true;
             this.AutoFiducial_radioButton.Text = "Both";
@@ -3592,7 +3593,7 @@
             this.RectangularFiducial_radioButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.RectangularFiducial_radioButton.Location = new System.Drawing.Point(11, 71);
             this.RectangularFiducial_radioButton.Name = "RectangularFiducial_radioButton";
-            this.RectangularFiducial_radioButton.Size = new System.Drawing.Size(56, 19);
+            this.RectangularFiducial_radioButton.Size = new System.Drawing.Size(49, 17);
             this.RectangularFiducial_radioButton.TabIndex = 132;
             this.RectangularFiducial_radioButton.TabStop = true;
             this.RectangularFiducial_radioButton.Text = "Rect.";
@@ -3605,7 +3606,7 @@
             this.RoundFiducial_radioButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.RoundFiducial_radioButton.Location = new System.Drawing.Point(11, 48);
             this.RoundFiducial_radioButton.Name = "RoundFiducial_radioButton";
-            this.RoundFiducial_radioButton.Size = new System.Drawing.Size(65, 19);
+            this.RoundFiducial_radioButton.Size = new System.Drawing.Size(56, 17);
             this.RoundFiducial_radioButton.TabIndex = 131;
             this.RoundFiducial_radioButton.TabStop = true;
             this.RoundFiducial_radioButton.Text = "Round";
@@ -3618,7 +3619,7 @@
             this.label138.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.label138.Location = new System.Drawing.Point(199, 52);
             this.label138.Name = "label138";
-            this.label138.Size = new System.Drawing.Size(29, 15);
+            this.label138.Size = new System.Drawing.Size(23, 13);
             this.label138.TabIndex = 130;
             this.label138.Text = "mm";
             this.toolTip1.SetToolTip(this.label138, "Set the true size of the box on the image.");
@@ -3629,7 +3630,7 @@
             this.label137.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.label137.Location = new System.Drawing.Point(86, 52);
             this.label137.Name = "label137";
-            this.label137.Size = new System.Drawing.Size(65, 15);
+            this.label137.Size = new System.Drawing.Size(55, 13);
             this.label137.TabIndex = 129;
             this.label137.Text = "Tolerance:";
             this.toolTip1.SetToolTip(this.label137, "Set the true size of the box on the image.");
@@ -3639,7 +3640,7 @@
             this.FiducialsTolerance_textBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.FiducialsTolerance_textBox.Location = new System.Drawing.Point(147, 49);
             this.FiducialsTolerance_textBox.Name = "FiducialsTolerance_textBox";
-            this.FiducialsTolerance_textBox.Size = new System.Drawing.Size(46, 21);
+            this.FiducialsTolerance_textBox.Size = new System.Drawing.Size(46, 18);
             this.FiducialsTolerance_textBox.TabIndex = 128;
             this.toolTip1.SetToolTip(this.FiducialsTolerance_textBox, "Set the true size of the box on the image.");
             this.FiducialsTolerance_textBox.TextChanged += new System.EventHandler(this.FiducialsTolerance_textBox_TextChanged);
@@ -3770,7 +3771,7 @@
             this.DownCamFindCircles_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.DownCamFindCircles_checkBox.Location = new System.Drawing.Point(125, 73);
             this.DownCamFindCircles_checkBox.Name = "DownCamFindCircles_checkBox";
-            this.DownCamFindCircles_checkBox.Size = new System.Drawing.Size(93, 19);
+            this.DownCamFindCircles_checkBox.Size = new System.Drawing.Size(79, 17);
             this.DownCamFindCircles_checkBox.TabIndex = 43;
             this.DownCamFindCircles_checkBox.Text = "Find Circles";
             this.toolTip1.SetToolTip(this.DownCamFindCircles_checkBox, "Tries to find circles on the image,\r\nusing video processing from the table below." +
@@ -3796,7 +3797,7 @@
             this.CameraStatus_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.2F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.CameraStatus_label.Location = new System.Drawing.Point(446, 19);
             this.CameraStatus_label.Name = "CameraStatus_label";
-            this.CameraStatus_label.Size = new System.Drawing.Size(130, 20);
+            this.CameraStatus_label.Size = new System.Drawing.Size(113, 17);
             this.CameraStatus_label.TabIndex = 6;
             this.CameraStatus_label.Text = "Not connected";
             this.toolTip1.SetToolTip(this.CameraStatus_label, "Camera conection status");
@@ -3819,7 +3820,7 @@
             this.DownCameraDrawCross_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.DownCameraDrawCross_checkBox.Location = new System.Drawing.Point(6, 75);
             this.DownCameraDrawCross_checkBox.Name = "DownCameraDrawCross_checkBox";
-            this.DownCameraDrawCross_checkBox.Size = new System.Drawing.Size(92, 19);
+            this.DownCameraDrawCross_checkBox.Size = new System.Drawing.Size(80, 17);
             this.DownCameraDrawCross_checkBox.TabIndex = 11;
             this.DownCameraDrawCross_checkBox.Text = "Draw Cross";
             this.toolTip1.SetToolTip(this.DownCameraDrawCross_checkBox, "Draws crosshair cursor on the image");
@@ -3832,7 +3833,7 @@
             this.DownCameraDrawBox_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.DownCameraDrawBox_checkBox.Location = new System.Drawing.Point(6, 118);
             this.DownCameraDrawBox_checkBox.Name = "DownCameraDrawBox_checkBox";
-            this.DownCameraDrawBox_checkBox.Size = new System.Drawing.Size(82, 19);
+            this.DownCameraDrawBox_checkBox.Size = new System.Drawing.Size(72, 17);
             this.DownCameraDrawBox_checkBox.TabIndex = 25;
             this.DownCameraDrawBox_checkBox.Text = "Draw Box";
             this.toolTip1.SetToolTip(this.DownCameraDrawBox_checkBox, "Draws a box on the image\r\n(Used to set camera scale)\r\n");
@@ -3857,7 +3858,7 @@
             this.label53.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label53.Location = new System.Drawing.Point(447, 2);
             this.label53.Name = "label53";
-            this.label53.Size = new System.Drawing.Size(44, 15);
+            this.label53.Size = new System.Drawing.Size(40, 13);
             this.label53.TabIndex = 8;
             this.label53.Text = "Status:";
             // 
@@ -3867,7 +3868,7 @@
             this.Overlay_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Overlay_checkBox.Location = new System.Drawing.Point(17, 329);
             this.Overlay_checkBox.Name = "Overlay_checkBox";
-            this.Overlay_checkBox.Size = new System.Drawing.Size(169, 21);
+            this.Overlay_checkBox.Size = new System.Drawing.Size(131, 17);
             this.Overlay_checkBox.TabIndex = 31;
             this.Overlay_checkBox.Text = "Draw Snapshot, color:";
             this.Overlay_checkBox.UseVisualStyleBackColor = true;
@@ -4133,9 +4134,9 @@
             this.UpCamera_tabPage.Controls.Add(this.UpCameraBoxY_textBox);
             this.UpCamera_tabPage.Controls.Add(this.UpCameraBoxX_textBox);
             this.UpCamera_tabPage.Controls.Add(this.label104);
-            this.UpCamera_tabPage.Location = new System.Drawing.Point(4, 25);
+            this.UpCamera_tabPage.Location = new System.Drawing.Point(4, 22);
             this.UpCamera_tabPage.Name = "UpCamera_tabPage";
-            this.UpCamera_tabPage.Size = new System.Drawing.Size(579, 591);
+            this.UpCamera_tabPage.Size = new System.Drawing.Size(579, 594);
             this.UpCamera_tabPage.TabIndex = 4;
             this.UpCamera_tabPage.Text = "Up Looking Camera";
             this.UpCamera_tabPage.UseVisualStyleBackColor = true;
@@ -4146,7 +4147,7 @@
             this.label105.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.label105.Location = new System.Drawing.Point(292, 74);
             this.label105.Name = "label105";
-            this.label105.Size = new System.Drawing.Size(56, 15);
+            this.label105.Size = new System.Drawing.Size(49, 13);
             this.label105.TabIndex = 161;
             this.label105.Text = "Box size:";
             this.toolTip1.SetToolTip(this.label105, "Set the true size of the box on the image.");
@@ -4157,7 +4158,7 @@
             this.label106.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label106.Location = new System.Drawing.Point(475, 76);
             this.label106.Name = "label106";
-            this.label106.Size = new System.Drawing.Size(110, 15);
+            this.label106.Size = new System.Drawing.Size(94, 13);
             this.label106.TabIndex = 160;
             this.label106.Text = "Desired resolution:";
             this.toolTip1.SetToolTip(this.label106, "Set the native camera resolution here");
@@ -4168,7 +4169,7 @@
             this.label160.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label160.Location = new System.Drawing.Point(500, 95);
             this.label160.Name = "label160";
-            this.label160.Size = new System.Drawing.Size(18, 15);
+            this.label160.Size = new System.Drawing.Size(17, 13);
             this.label160.TabIndex = 156;
             this.label160.Text = "X:";
             this.toolTip1.SetToolTip(this.label160, "Set the native camera resolution here");
@@ -4179,7 +4180,7 @@
             this.label161.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label161.Location = new System.Drawing.Point(500, 119);
             this.label161.Name = "label161";
-            this.label161.Size = new System.Drawing.Size(17, 15);
+            this.label161.Size = new System.Drawing.Size(17, 13);
             this.label161.TabIndex = 157;
             this.label161.Text = "Y:";
             this.toolTip1.SetToolTip(this.label161, "Set the native camera resolution here");
@@ -4189,7 +4190,7 @@
             this.UpCameraDesiredX_textBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.UpCameraDesiredX_textBox.Location = new System.Drawing.Point(523, 92);
             this.UpCameraDesiredX_textBox.Name = "UpCameraDesiredX_textBox";
-            this.UpCameraDesiredX_textBox.Size = new System.Drawing.Size(46, 21);
+            this.UpCameraDesiredX_textBox.Size = new System.Drawing.Size(46, 18);
             this.UpCameraDesiredX_textBox.TabIndex = 158;
             this.toolTip1.SetToolTip(this.UpCameraDesiredX_textBox, "Set the native camera resolution here");
             this.UpCameraDesiredX_textBox.TextChanged += new System.EventHandler(this.UpCameraDesiredX_textBox_TextChanged);
@@ -4199,7 +4200,7 @@
             this.UpCameraDesiredY_textBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.UpCameraDesiredY_textBox.Location = new System.Drawing.Point(523, 116);
             this.UpCameraDesiredY_textBox.Name = "UpCameraDesiredY_textBox";
-            this.UpCameraDesiredY_textBox.Size = new System.Drawing.Size(46, 21);
+            this.UpCameraDesiredY_textBox.Size = new System.Drawing.Size(46, 18);
             this.UpCameraDesiredY_textBox.TabIndex = 159;
             this.toolTip1.SetToolTip(this.UpCameraDesiredY_textBox, "Set the native camera resolution here");
             this.UpCameraDesiredY_textBox.TextChanged += new System.EventHandler(this.UpCameraDesiredY_textBox_TextChanged);
@@ -4210,7 +4211,7 @@
             this.label162.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.label162.Location = new System.Drawing.Point(292, 93);
             this.label162.Name = "label162";
-            this.label162.Size = new System.Drawing.Size(18, 15);
+            this.label162.Size = new System.Drawing.Size(17, 13);
             this.label162.TabIndex = 154;
             this.label162.Text = "X:";
             this.toolTip1.SetToolTip(this.label162, "Set the true size of the box on the image.");
@@ -4221,7 +4222,7 @@
             this.label163.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.label163.Location = new System.Drawing.Point(292, 119);
             this.label163.Name = "label163";
-            this.label163.Size = new System.Drawing.Size(17, 15);
+            this.label163.Size = new System.Drawing.Size(17, 13);
             this.label163.TabIndex = 155;
             this.label163.Text = "Y:";
             this.toolTip1.SetToolTip(this.label163, "Set the true size of the box on the image.");
@@ -4377,7 +4378,7 @@
             this.UpcamSnapshot_ColorBox.Location = new System.Drawing.Point(460, 302);
             this.UpcamSnapshot_ColorBox.Name = "UpcamSnapshot_ColorBox";
             this.UpcamSnapshot_ColorBox.ReadOnly = true;
-            this.UpcamSnapshot_ColorBox.Size = new System.Drawing.Size(21, 22);
+            this.UpcamSnapshot_ColorBox.Size = new System.Drawing.Size(21, 20);
             this.UpcamSnapshot_ColorBox.TabIndex = 143;
             this.toolTip1.SetToolTip(this.UpcamSnapshot_ColorBox, "Set parameters for the selected algorithm");
             this.UpcamSnapshot_ColorBox.Visible = false;
@@ -4389,7 +4390,7 @@
             this.UpCamOverlay_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.UpCamOverlay_checkBox.Location = new System.Drawing.Point(325, 304);
             this.UpCamOverlay_checkBox.Name = "UpCamOverlay_checkBox";
-            this.UpCamOverlay_checkBox.Size = new System.Drawing.Size(169, 21);
+            this.UpCamOverlay_checkBox.Size = new System.Drawing.Size(131, 17);
             this.UpCamOverlay_checkBox.TabIndex = 142;
             this.UpCamOverlay_checkBox.Text = "Draw Snapshot, color:";
             this.UpCamOverlay_checkBox.UseVisualStyleBackColor = true;
@@ -4524,7 +4525,7 @@
             this.UpCam_FindComponents_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.UpCam_FindComponents_checkBox.Location = new System.Drawing.Point(106, 98);
             this.UpCam_FindComponents_checkBox.Name = "UpCam_FindComponents_checkBox";
-            this.UpCam_FindComponents_checkBox.Size = new System.Drawing.Size(126, 19);
+            this.UpCam_FindComponents_checkBox.Size = new System.Drawing.Size(108, 17);
             this.UpCam_FindComponents_checkBox.TabIndex = 70;
             this.UpCam_FindComponents_checkBox.Text = "Find Components";
             this.UpCam_FindComponents_checkBox.UseVisualStyleBackColor = true;
@@ -4536,7 +4537,7 @@
             this.checkBox2.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.checkBox2.Location = new System.Drawing.Point(106, 121);
             this.checkBox2.Name = "checkBox2";
-            this.checkBox2.Size = new System.Drawing.Size(118, 19);
+            this.checkBox2.Size = new System.Drawing.Size(101, 17);
             this.checkBox2.TabIndex = 69;
             this.checkBox2.Text = "Find Rectangles";
             this.toolTip1.SetToolTip(this.checkBox2, "Tries to find rectangels on the image,\r\nusing video processing from the table bel" +
@@ -4573,7 +4574,7 @@
             this.label154.AutoSize = true;
             this.label154.Location = new System.Drawing.Point(107, 15);
             this.label154.Name = "label154";
-            this.label154.Size = new System.Drawing.Size(140, 17);
+            this.label154.Size = new System.Drawing.Size(106, 13);
             this.label154.TabIndex = 159;
             this.label154.Text = "Alternative functions:";
             // 
@@ -4582,7 +4583,7 @@
             this.label153.AutoSize = true;
             this.label153.Location = new System.Drawing.Point(8, 16);
             this.label153.Name = "label153";
-            this.label153.Size = new System.Drawing.Size(118, 17);
+            this.label153.Size = new System.Drawing.Size(90, 13);
             this.label153.TabIndex = 158;
             this.label153.Text = "Default functions:";
             // 
@@ -4626,7 +4627,7 @@
             this.label147.AutoSize = true;
             this.label147.Location = new System.Drawing.Point(219, 89);
             this.label147.Name = "label147";
-            this.label147.Size = new System.Drawing.Size(84, 17);
+            this.label147.Size = new System.Drawing.Size(64, 13);
             this.label147.TabIndex = 154;
             this.label147.Text = "Max. radius:";
             // 
@@ -4634,7 +4635,7 @@
             // 
             this.NozzleDistance_textBox.Location = new System.Drawing.Point(289, 34);
             this.NozzleDistance_textBox.Name = "NozzleDistance_textBox";
-            this.NozzleDistance_textBox.Size = new System.Drawing.Size(52, 22);
+            this.NozzleDistance_textBox.Size = new System.Drawing.Size(52, 20);
             this.NozzleDistance_textBox.TabIndex = 149;
             this.NozzleDistance_textBox.KeyUp += new System.Windows.Forms.KeyEventHandler(this.NozzleDistance_textBox_KeyUp);
             // 
@@ -4654,7 +4655,7 @@
             this.label121.AutoSize = true;
             this.label121.Location = new System.Drawing.Point(210, 37);
             this.label121.Name = "label121";
-            this.label121.Size = new System.Drawing.Size(94, 17);
+            this.label121.Size = new System.Drawing.Size(73, 13);
             this.label121.TabIndex = 150;
             this.label121.Text = "Max distance:";
             // 
@@ -4662,7 +4663,7 @@
             // 
             this.NozzleMaxSize_textBox.Location = new System.Drawing.Point(289, 86);
             this.NozzleMaxSize_textBox.Name = "NozzleMaxSize_textBox";
-            this.NozzleMaxSize_textBox.Size = new System.Drawing.Size(52, 22);
+            this.NozzleMaxSize_textBox.Size = new System.Drawing.Size(52, 20);
             this.NozzleMaxSize_textBox.TabIndex = 153;
             this.NozzleMaxSize_textBox.KeyUp += new System.Windows.Forms.KeyEventHandler(this.NozzleMaxSize_textBox_KeyUp);
             // 
@@ -4682,7 +4683,7 @@
             // 
             this.NozzleMinSize_textBox.Location = new System.Drawing.Point(289, 60);
             this.NozzleMinSize_textBox.Name = "NozzleMinSize_textBox";
-            this.NozzleMinSize_textBox.Size = new System.Drawing.Size(52, 22);
+            this.NozzleMinSize_textBox.Size = new System.Drawing.Size(52, 20);
             this.NozzleMinSize_textBox.TabIndex = 151;
             this.NozzleMinSize_textBox.KeyUp += new System.Windows.Forms.KeyEventHandler(this.NozzleMinSize_textBox_KeyUp);
             // 
@@ -4703,7 +4704,7 @@
             this.label130.AutoSize = true;
             this.label130.Location = new System.Drawing.Point(222, 63);
             this.label130.Name = "label130";
-            this.label130.Size = new System.Drawing.Size(81, 17);
+            this.label130.Size = new System.Drawing.Size(61, 13);
             this.label130.TabIndex = 152;
             this.label130.Text = "Min. radius:";
             // 
@@ -4713,7 +4714,7 @@
             this.UpCamFindCircles_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.UpCamFindCircles_checkBox.Location = new System.Drawing.Point(106, 75);
             this.UpCamFindCircles_checkBox.Name = "UpCamFindCircles_checkBox";
-            this.UpCamFindCircles_checkBox.Size = new System.Drawing.Size(93, 19);
+            this.UpCamFindCircles_checkBox.Size = new System.Drawing.Size(79, 17);
             this.UpCamFindCircles_checkBox.TabIndex = 68;
             this.UpCamFindCircles_checkBox.Text = "Find Circles";
             this.toolTip1.SetToolTip(this.UpCamFindCircles_checkBox, "Tries to find circles on the image,\r\nusing video processing from the table below." +
@@ -4728,7 +4729,7 @@
             this.UpCam_comboBox.FormattingEnabled = true;
             this.UpCam_comboBox.Location = new System.Drawing.Point(3, 8);
             this.UpCam_comboBox.Name = "UpCam_comboBox";
-            this.UpCam_comboBox.Size = new System.Drawing.Size(132, 25);
+            this.UpCam_comboBox.Size = new System.Drawing.Size(132, 21);
             this.UpCam_comboBox.TabIndex = 44;
             this.toolTip1.SetToolTip(this.UpCam_comboBox, "List of USB cameras found on this computer.\r\nSelect up looking camera form this l" +
         "ist.\r\n");
@@ -4739,7 +4740,7 @@
             this.UpCameraDrawDashedCross_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.UpCameraDrawDashedCross_checkBox.Location = new System.Drawing.Point(38, 181);
             this.UpCameraDrawDashedCross_checkBox.Name = "UpCameraDrawDashedCross_checkBox";
-            this.UpCameraDrawDashedCross_checkBox.Size = new System.Drawing.Size(138, 19);
+            this.UpCameraDrawDashedCross_checkBox.Size = new System.Drawing.Size(120, 17);
             this.UpCameraDrawDashedCross_checkBox.TabIndex = 67;
             this.UpCameraDrawDashedCross_checkBox.Text = "Draw Dashed Cross";
             this.UpCameraDrawDashedCross_checkBox.UseVisualStyleBackColor = true;
@@ -4752,7 +4753,7 @@
             this.UpCameraBoxYmmPerPixel_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.UpCameraBoxYmmPerPixel_label.Location = new System.Drawing.Point(396, 119);
             this.UpCameraBoxYmmPerPixel_label.Name = "UpCameraBoxYmmPerPixel_label";
-            this.UpCameraBoxYmmPerPixel_label.Size = new System.Drawing.Size(19, 15);
+            this.UpCameraBoxYmmPerPixel_label.Size = new System.Drawing.Size(16, 13);
             this.UpCameraBoxYmmPerPixel_label.TabIndex = 66;
             this.UpCameraBoxYmmPerPixel_label.Text = "---";
             this.toolTip1.SetToolTip(this.UpCameraBoxYmmPerPixel_label, "Set the true size of the box on the image.");
@@ -4763,7 +4764,7 @@
             this.UpCameraDrawBox_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.UpCameraDrawBox_checkBox.Location = new System.Drawing.Point(6, 98);
             this.UpCameraDrawBox_checkBox.Name = "UpCameraDrawBox_checkBox";
-            this.UpCameraDrawBox_checkBox.Size = new System.Drawing.Size(82, 19);
+            this.UpCameraDrawBox_checkBox.Size = new System.Drawing.Size(72, 17);
             this.UpCameraDrawBox_checkBox.TabIndex = 64;
             this.UpCameraDrawBox_checkBox.Text = "Draw Box";
             this.toolTip1.SetToolTip(this.UpCameraDrawBox_checkBox, "Draws a box on the image\r\n(Used to set camera scale)");
@@ -4788,7 +4789,7 @@
             this.UpCameraDrawCross_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.UpCameraDrawCross_checkBox.Location = new System.Drawing.Point(6, 75);
             this.UpCameraDrawCross_checkBox.Name = "UpCameraDrawCross_checkBox";
-            this.UpCameraDrawCross_checkBox.Size = new System.Drawing.Size(92, 19);
+            this.UpCameraDrawCross_checkBox.Size = new System.Drawing.Size(80, 17);
             this.UpCameraDrawCross_checkBox.TabIndex = 50;
             this.UpCameraDrawCross_checkBox.Text = "Draw Cross";
             this.toolTip1.SetToolTip(this.UpCameraDrawCross_checkBox, "Draws crosshair cursor on the image");
@@ -4801,7 +4802,7 @@
             this.label110.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.label110.Location = new System.Drawing.Point(447, 2);
             this.label110.Name = "label110";
-            this.label110.Size = new System.Drawing.Size(44, 15);
+            this.label110.Size = new System.Drawing.Size(40, 13);
             this.label110.TabIndex = 47;
             this.label110.Text = "Status:";
             // 
@@ -4811,7 +4812,7 @@
             this.UpCameraBoxXmmPerPixel_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.UpCameraBoxXmmPerPixel_label.Location = new System.Drawing.Point(396, 93);
             this.UpCameraBoxXmmPerPixel_label.Name = "UpCameraBoxXmmPerPixel_label";
-            this.UpCameraBoxXmmPerPixel_label.Size = new System.Drawing.Size(19, 15);
+            this.UpCameraBoxXmmPerPixel_label.Size = new System.Drawing.Size(16, 13);
             this.UpCameraBoxXmmPerPixel_label.TabIndex = 65;
             this.UpCameraBoxXmmPerPixel_label.Text = "---";
             this.toolTip1.SetToolTip(this.UpCameraBoxXmmPerPixel_label, "Set the true size of the box on the image.");
@@ -4834,7 +4835,7 @@
             this.label103.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.label103.Location = new System.Drawing.Point(367, 119);
             this.label103.Name = "label103";
-            this.label103.Size = new System.Drawing.Size(29, 15);
+            this.label103.Size = new System.Drawing.Size(23, 13);
             this.label103.TabIndex = 62;
             this.label103.Text = "mm";
             this.toolTip1.SetToolTip(this.label103, "Set the true size of the box on the image.");
@@ -4844,7 +4845,7 @@
             this.UpCameraBoxY_textBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.UpCameraBoxY_textBox.Location = new System.Drawing.Point(315, 116);
             this.UpCameraBoxY_textBox.Name = "UpCameraBoxY_textBox";
-            this.UpCameraBoxY_textBox.Size = new System.Drawing.Size(46, 21);
+            this.UpCameraBoxY_textBox.Size = new System.Drawing.Size(46, 18);
             this.UpCameraBoxY_textBox.TabIndex = 60;
             this.toolTip1.SetToolTip(this.UpCameraBoxY_textBox, "Set the true size of the box on the image.");
             this.UpCameraBoxY_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.UpCameraBoxY_textBox_KeyPress);
@@ -4855,7 +4856,7 @@
             this.UpCameraBoxX_textBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.UpCameraBoxX_textBox.Location = new System.Drawing.Point(315, 90);
             this.UpCameraBoxX_textBox.Name = "UpCameraBoxX_textBox";
-            this.UpCameraBoxX_textBox.Size = new System.Drawing.Size(46, 21);
+            this.UpCameraBoxX_textBox.Size = new System.Drawing.Size(46, 18);
             this.UpCameraBoxX_textBox.TabIndex = 59;
             this.toolTip1.SetToolTip(this.UpCameraBoxX_textBox, "Set the true size of the box on the image.");
             this.UpCameraBoxX_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.UpCameraBoxX_textBox_KeyPress);
@@ -4867,7 +4868,7 @@
             this.label104.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
             this.label104.Location = new System.Drawing.Point(367, 93);
             this.label104.Name = "label104";
-            this.label104.Size = new System.Drawing.Size(29, 15);
+            this.label104.Size = new System.Drawing.Size(23, 13);
             this.label104.TabIndex = 61;
             this.label104.Text = "mm";
             this.toolTip1.SetToolTip(this.label104, "Set the true size of the box on the image.");
@@ -4878,7 +4879,7 @@
             this.DownCameraDrawDashedCross_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.DownCameraDrawDashedCross_checkBox.Location = new System.Drawing.Point(600, 188);
             this.DownCameraDrawDashedCross_checkBox.Name = "DownCameraDrawDashedCross_checkBox";
-            this.DownCameraDrawDashedCross_checkBox.Size = new System.Drawing.Size(155, 21);
+            this.DownCameraDrawDashedCross_checkBox.Size = new System.Drawing.Size(120, 17);
             this.DownCameraDrawDashedCross_checkBox.TabIndex = 42;
             this.DownCameraDrawDashedCross_checkBox.Text = "Draw Dashed Cross";
             this.DownCameraDrawDashedCross_checkBox.UseVisualStyleBackColor = true;
@@ -4891,7 +4892,7 @@
             this.label101.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.792F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label101.Location = new System.Drawing.Point(579, 497);
             this.label101.Name = "label101";
-            this.label101.Size = new System.Drawing.Size(59, 20);
+            this.label101.Size = new System.Drawing.Size(50, 17);
             this.label101.TabIndex = 117;
             this.label101.Text = "Pickup";
             // 
@@ -4901,7 +4902,7 @@
             this.label100.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.792F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label100.Location = new System.Drawing.Point(491, 497);
             this.label100.Name = "label100";
-            this.label100.Size = new System.Drawing.Size(82, 20);
+            this.label100.Size = new System.Drawing.Size(67, 17);
             this.label100.TabIndex = 116;
             this.label100.Text = "PCB zero";
             // 
@@ -4911,7 +4912,7 @@
             this.DownCameraDrawGrid_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.DownCameraDrawGrid_checkBox.Location = new System.Drawing.Point(607, 165);
             this.DownCameraDrawGrid_checkBox.Name = "DownCameraDrawGrid_checkBox";
-            this.DownCameraDrawGrid_checkBox.Size = new System.Drawing.Size(84, 19);
+            this.DownCameraDrawGrid_checkBox.Size = new System.Drawing.Size(73, 17);
             this.DownCameraDrawGrid_checkBox.TabIndex = 147;
             this.DownCameraDrawGrid_checkBox.Text = "Draw Grid";
             this.toolTip1.SetToolTip(this.DownCameraDrawGrid_checkBox, "Draws a box on the image\r\n(Used to set camera scale)\r\n");
@@ -4925,7 +4926,7 @@
             this.label55.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.792F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label55.Location = new System.Drawing.Point(391, 497);
             this.label55.Name = "label55";
-            this.label55.Size = new System.Drawing.Size(94, 20);
+            this.label55.Size = new System.Drawing.Size(79, 17);
             this.label55.TabIndex = 115;
             this.label55.Text = "Up Camera";
             // 
@@ -4987,7 +4988,7 @@
             this.label99.AutoSize = true;
             this.label99.Location = new System.Drawing.Point(416, 582);
             this.label99.Name = "label99";
-            this.label99.Size = new System.Drawing.Size(21, 17);
+            this.label99.Size = new System.Drawing.Size(17, 13);
             this.label99.TabIndex = 71;
             this.label99.Text = "Y:";
             // 
@@ -4996,7 +4997,7 @@
             this.label98.AutoSize = true;
             this.label98.Location = new System.Drawing.Point(416, 556);
             this.label98.Name = "label98";
-            this.label98.Size = new System.Drawing.Size(21, 17);
+            this.label98.Size = new System.Drawing.Size(17, 13);
             this.label98.TabIndex = 70;
             this.label98.Text = "X:";
             // 
@@ -5004,7 +5005,7 @@
             // 
             this.UpcamPositionY_textBox.Location = new System.Drawing.Point(439, 579);
             this.UpcamPositionY_textBox.Name = "UpcamPositionY_textBox";
-            this.UpcamPositionY_textBox.Size = new System.Drawing.Size(46, 22);
+            this.UpcamPositionY_textBox.Size = new System.Drawing.Size(46, 20);
             this.UpcamPositionY_textBox.TabIndex = 69;
             this.UpcamPositionY_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.UpcamPositionY_textBox_KeyPress);
             this.UpcamPositionY_textBox.Leave += new System.EventHandler(this.UpcamPositionY_textBox_Leave);
@@ -5013,7 +5014,7 @@
             // 
             this.UpcamPositionX_textBox.Location = new System.Drawing.Point(439, 553);
             this.UpcamPositionX_textBox.Name = "UpcamPositionX_textBox";
-            this.UpcamPositionX_textBox.Size = new System.Drawing.Size(46, 22);
+            this.UpcamPositionX_textBox.Size = new System.Drawing.Size(46, 20);
             this.UpcamPositionX_textBox.TabIndex = 68;
             this.UpcamPositionX_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.UpcamPositionX_textBox_KeyPress);
             this.UpcamPositionX_textBox.Leave += new System.EventHandler(this.UpcamPositionX_textBox_Leave);
@@ -5022,7 +5023,7 @@
             // 
             this.NozzleOffsetY_textBox.Location = new System.Drawing.Point(120, 597);
             this.NozzleOffsetY_textBox.Name = "NozzleOffsetY_textBox";
-            this.NozzleOffsetY_textBox.Size = new System.Drawing.Size(36, 22);
+            this.NozzleOffsetY_textBox.Size = new System.Drawing.Size(36, 20);
             this.NozzleOffsetY_textBox.TabIndex = 86;
             this.NozzleOffsetY_textBox.Text = "6.99";
             this.toolTip1.SetToolTip(this.NozzleOffsetY_textBox, "Nominal postion difference between\r\nthe Nozzle tip and down camera image center.");
@@ -5033,7 +5034,7 @@
             // 
             this.NozzleOffsetX_textBox.Location = new System.Drawing.Point(31, 597);
             this.NozzleOffsetX_textBox.Name = "NozzleOffsetX_textBox";
-            this.NozzleOffsetX_textBox.Size = new System.Drawing.Size(37, 22);
+            this.NozzleOffsetX_textBox.Size = new System.Drawing.Size(37, 20);
             this.NozzleOffsetX_textBox.TabIndex = 85;
             this.NozzleOffsetX_textBox.Text = "42.88";
             this.toolTip1.SetToolTip(this.NozzleOffsetX_textBox, "Nominal postion difference between\r\nthe Nozzle tip and down camera image center.");
@@ -5044,7 +5045,7 @@
             // 
             this.PickupCenterY_textBox.Location = new System.Drawing.Point(600, 579);
             this.PickupCenterY_textBox.Name = "PickupCenterY_textBox";
-            this.PickupCenterY_textBox.Size = new System.Drawing.Size(46, 22);
+            this.PickupCenterY_textBox.Size = new System.Drawing.Size(46, 20);
             this.PickupCenterY_textBox.TabIndex = 39;
             this.PickupCenterY_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.PickupCenterY_textBox_KeyPress);
             this.PickupCenterY_textBox.Leave += new System.EventHandler(this.PickupCenterY_textBox_Leave);
@@ -5053,7 +5054,7 @@
             // 
             this.PickupCenterX_textBox.Location = new System.Drawing.Point(600, 553);
             this.PickupCenterX_textBox.Name = "PickupCenterX_textBox";
-            this.PickupCenterX_textBox.Size = new System.Drawing.Size(46, 22);
+            this.PickupCenterX_textBox.Size = new System.Drawing.Size(46, 20);
             this.PickupCenterX_textBox.TabIndex = 38;
             this.PickupCenterX_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.PickupCenterX_textBox_KeyPress);
             this.PickupCenterX_textBox.Leave += new System.EventHandler(this.PickupCenterX_textBox_Leave);
@@ -5062,7 +5063,7 @@
             // 
             this.JigY_textBox.Location = new System.Drawing.Point(518, 579);
             this.JigY_textBox.Name = "JigY_textBox";
-            this.JigY_textBox.Size = new System.Drawing.Size(46, 22);
+            this.JigY_textBox.Size = new System.Drawing.Size(46, 20);
             this.JigY_textBox.TabIndex = 35;
             this.JigY_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.JigY_textBox_KeyPress);
             this.JigY_textBox.Leave += new System.EventHandler(this.JigY_textBox_Leave);
@@ -5071,7 +5072,7 @@
             // 
             this.JigX_textBox.Location = new System.Drawing.Point(518, 553);
             this.JigX_textBox.Name = "JigX_textBox";
-            this.JigX_textBox.Size = new System.Drawing.Size(46, 22);
+            this.JigX_textBox.Size = new System.Drawing.Size(46, 20);
             this.JigX_textBox.TabIndex = 34;
             this.JigX_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.JigX_textBox_KeyPress);
             this.JigX_textBox.Leave += new System.EventHandler(this.JigX_textBox_Leave);
@@ -5081,7 +5082,7 @@
             this.label149.AutoSize = true;
             this.label149.Location = new System.Drawing.Point(162, 601);
             this.label149.Name = "label149";
-            this.label149.Size = new System.Drawing.Size(30, 17);
+            this.label149.Size = new System.Drawing.Size(23, 13);
             this.label149.TabIndex = 90;
             this.label149.Text = "mm";
             // 
@@ -5090,7 +5091,7 @@
             this.label148.AutoSize = true;
             this.label148.Location = new System.Drawing.Point(72, 601);
             this.label148.Name = "label148";
-            this.label148.Size = new System.Drawing.Size(30, 17);
+            this.label148.Size = new System.Drawing.Size(23, 13);
             this.label148.TabIndex = 89;
             this.label148.Text = "mm";
             // 
@@ -5099,7 +5100,7 @@
             this.label146.AutoSize = true;
             this.label146.Location = new System.Drawing.Point(97, 601);
             this.label146.Name = "label146";
-            this.label146.Size = new System.Drawing.Size(21, 17);
+            this.label146.Size = new System.Drawing.Size(17, 13);
             this.label146.TabIndex = 88;
             this.label146.Text = "Y:";
             // 
@@ -5108,7 +5109,7 @@
             this.label143.AutoSize = true;
             this.label143.Location = new System.Drawing.Point(8, 601);
             this.label143.Name = "label143";
-            this.label143.Size = new System.Drawing.Size(21, 17);
+            this.label143.Size = new System.Drawing.Size(17, 13);
             this.label143.TabIndex = 87;
             this.label143.Text = "X:";
             // 
@@ -5117,7 +5118,7 @@
             this.Z0toPCB_CamerasTab_label.AutoSize = true;
             this.Z0toPCB_CamerasTab_label.Location = new System.Drawing.Point(267, 601);
             this.Z0toPCB_CamerasTab_label.Name = "Z0toPCB_CamerasTab_label";
-            this.Z0toPCB_CamerasTab_label.Size = new System.Drawing.Size(70, 17);
+            this.Z0toPCB_CamerasTab_label.Size = new System.Drawing.Size(53, 13);
             this.Z0toPCB_CamerasTab_label.TabIndex = 84;
             this.Z0toPCB_CamerasTab_label.Text = "37.00 mm";
             // 
@@ -5126,7 +5127,7 @@
             this.label120.AutoSize = true;
             this.label120.Location = new System.Drawing.Point(205, 601);
             this.label120.Name = "label120";
-            this.label120.Size = new System.Drawing.Size(76, 17);
+            this.label120.Size = new System.Drawing.Size(59, 13);
             this.label120.TabIndex = 83;
             this.label120.Text = "Z0 to PCB:";
             // 
@@ -5147,7 +5148,7 @@
             this.label115.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.792F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label115.Location = new System.Drawing.Point(9, 497);
             this.label115.Name = "label115";
-            this.label115.Size = new System.Drawing.Size(114, 20);
+            this.label115.Size = new System.Drawing.Size(96, 17);
             this.label115.TabIndex = 49;
             this.label115.Text = "Nozzle Setup:";
             // 
@@ -5156,7 +5157,7 @@
             this.label114.AutoSize = true;
             this.label114.Location = new System.Drawing.Point(9, 579);
             this.label114.Name = "label114";
-            this.label114.Size = new System.Drawing.Size(152, 17);
+            this.label114.Size = new System.Drawing.Size(114, 13);
             this.label114.TabIndex = 45;
             this.label114.Text = "Nozzle Nominal Offset:";
             // 
@@ -5207,7 +5208,7 @@
             this.label95.AutoSize = true;
             this.label95.Location = new System.Drawing.Point(577, 582);
             this.label95.Name = "label95";
-            this.label95.Size = new System.Drawing.Size(21, 17);
+            this.label95.Size = new System.Drawing.Size(17, 13);
             this.label95.TabIndex = 37;
             this.label95.Text = "Y:";
             // 
@@ -5216,7 +5217,7 @@
             this.label96.AutoSize = true;
             this.label96.Location = new System.Drawing.Point(577, 556);
             this.label96.Name = "label96";
-            this.label96.Size = new System.Drawing.Size(21, 17);
+            this.label96.Size = new System.Drawing.Size(17, 13);
             this.label96.TabIndex = 36;
             this.label96.Text = "X:";
             // 
@@ -5225,7 +5226,7 @@
             this.label93.AutoSize = true;
             this.label93.Location = new System.Drawing.Point(496, 582);
             this.label93.Name = "label93";
-            this.label93.Size = new System.Drawing.Size(21, 17);
+            this.label93.Size = new System.Drawing.Size(17, 13);
             this.label93.TabIndex = 33;
             this.label93.Text = "Y:";
             // 
@@ -5234,7 +5235,7 @@
             this.label94.AutoSize = true;
             this.label94.Location = new System.Drawing.Point(496, 556);
             this.label94.Name = "label94";
-            this.label94.Size = new System.Drawing.Size(21, 17);
+            this.label94.Size = new System.Drawing.Size(17, 13);
             this.label94.TabIndex = 32;
             this.label94.Text = "X:";
             // 
@@ -5243,7 +5244,7 @@
             this.ImageTest_checkBox.AutoSize = true;
             this.ImageTest_checkBox.Location = new System.Drawing.Point(283, 579);
             this.ImageTest_checkBox.Name = "ImageTest_checkBox";
-            this.ImageTest_checkBox.Size = new System.Drawing.Size(77, 21);
+            this.ImageTest_checkBox.Size = new System.Drawing.Size(61, 17);
             this.ImageTest_checkBox.TabIndex = 29;
             this.ImageTest_checkBox.Text = "Testing";
             this.ImageTest_checkBox.UseVisualStyleBackColor = true;
@@ -5263,6 +5264,7 @@
             // 
             // tabPageBasicSetup
             // 
+            this.tabPageBasicSetup.Controls.Add(this.SlackCompensationDistance_textBox);
             this.tabPageBasicSetup.Controls.Add(this.Ato0_button);
             this.tabPageBasicSetup.Controls.Add(this.VacuumInvert_checkBox);
             this.tabPageBasicSetup.Controls.Add(this.PumpInvert_checkBox);
@@ -5352,13 +5354,23 @@
             this.tabPageBasicSetup.Controls.Add(this.buttonConnectSerial);
             this.tabPageBasicSetup.Controls.Add(this.label2);
             this.tabPageBasicSetup.Controls.Add(this.comboBoxSerialPorts);
-            this.tabPageBasicSetup.Location = new System.Drawing.Point(4, 25);
+            this.tabPageBasicSetup.Location = new System.Drawing.Point(4, 22);
             this.tabPageBasicSetup.Name = "tabPageBasicSetup";
             this.tabPageBasicSetup.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPageBasicSetup.Size = new System.Drawing.Size(1245, 632);
+            this.tabPageBasicSetup.Size = new System.Drawing.Size(1245, 635);
             this.tabPageBasicSetup.TabIndex = 1;
             this.tabPageBasicSetup.Text = "Basic Setup";
             this.tabPageBasicSetup.UseVisualStyleBackColor = true;
+            // 
+            // SlackCompensationDistance_textBox
+            // 
+            this.SlackCompensationDistance_textBox.Location = new System.Drawing.Point(1173, 165);
+            this.SlackCompensationDistance_textBox.Name = "SlackCompensationDistance_textBox";
+            this.SlackCompensationDistance_textBox.Size = new System.Drawing.Size(44, 20);
+            this.SlackCompensationDistance_textBox.TabIndex = 104;
+            this.toolTip1.SetToolTip(this.SlackCompensationDistance_textBox, "This is the amount of slack compensation to apply in mm\'s when Slack Compensation" +
+        " is checked");
+            this.SlackCompensationDistance_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.SlackCompensationDistance_textBox_KeyPress);
             // 
             // Ato0_button
             // 
@@ -5376,7 +5388,7 @@
             this.VacuumInvert_checkBox.AutoSize = true;
             this.VacuumInvert_checkBox.Location = new System.Drawing.Point(779, 35);
             this.VacuumInvert_checkBox.Name = "VacuumInvert_checkBox";
-            this.VacuumInvert_checkBox.Size = new System.Drawing.Size(65, 21);
+            this.VacuumInvert_checkBox.Size = new System.Drawing.Size(52, 17);
             this.VacuumInvert_checkBox.TabIndex = 113;
             this.VacuumInvert_checkBox.Text = "invert";
             this.toolTip1.SetToolTip(this.VacuumInvert_checkBox, "inverts the polarity of vacuum contrrol line output");
@@ -5388,7 +5400,7 @@
             this.PumpInvert_checkBox.AutoSize = true;
             this.PumpInvert_checkBox.Location = new System.Drawing.Point(779, 15);
             this.PumpInvert_checkBox.Name = "PumpInvert_checkBox";
-            this.PumpInvert_checkBox.Size = new System.Drawing.Size(65, 21);
+            this.PumpInvert_checkBox.Size = new System.Drawing.Size(52, 17);
             this.PumpInvert_checkBox.TabIndex = 112;
             this.PumpInvert_checkBox.Text = "invert";
             this.toolTip1.SetToolTip(this.PumpInvert_checkBox, "Inverts the polarity of pump output");
@@ -5457,7 +5469,7 @@
             this.Board_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Board_label.Location = new System.Drawing.Point(510, 7);
             this.Board_label.Name = "Board_label";
-            this.Board_label.Size = new System.Drawing.Size(196, 24);
+            this.Board_label.Size = new System.Drawing.Size(158, 18);
             this.Board_label.TabIndex = 106;
             this.Board_label.Text = "Control Board Settings";
             this.toolTip1.SetToolTip(this.Board_label, "Connection status");
@@ -5468,7 +5480,7 @@
             this.label159.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label159.Location = new System.Drawing.Point(260, 7);
             this.label159.Name = "label159";
-            this.label159.Size = new System.Drawing.Size(174, 24);
+            this.label159.Size = new System.Drawing.Size(136, 18);
             this.label159.TabIndex = 105;
             this.label159.Text = "Application Settings";
             this.toolTip1.SetToolTip(this.label159, "Connection status");
@@ -5477,7 +5489,7 @@
             // 
             this.NozzleBelowPCB_textBox.Location = new System.Drawing.Point(899, 516);
             this.NozzleBelowPCB_textBox.Name = "NozzleBelowPCB_textBox";
-            this.NozzleBelowPCB_textBox.Size = new System.Drawing.Size(55, 22);
+            this.NozzleBelowPCB_textBox.Size = new System.Drawing.Size(55, 20);
             this.NozzleBelowPCB_textBox.TabIndex = 104;
             this.NozzleBelowPCB_textBox.TextChanged += new System.EventHandler(this.NozzleBelowPCB_textBox_TextChanged);
             // 
@@ -5486,7 +5498,7 @@
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(756, 519);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(178, 17);
+            this.label1.Size = new System.Drawing.Size(137, 13);
             this.label1.TabIndex = 103;
             this.label1.Text = "Allow Nozzle to below PCB:";
             // 
@@ -5495,7 +5507,7 @@
             this.DisableLog_checkBox.AutoSize = true;
             this.DisableLog_checkBox.Location = new System.Drawing.Point(290, 612);
             this.DisableLog_checkBox.Name = "DisableLog_checkBox";
-            this.DisableLog_checkBox.Size = new System.Drawing.Size(111, 21);
+            this.DisableLog_checkBox.Size = new System.Drawing.Size(87, 17);
             this.DisableLog_checkBox.TabIndex = 102;
             this.DisableLog_checkBox.Text = "Mute logging";
             this.toolTip1.SetToolTip(this.DisableLog_checkBox, "If checked, reduces the amout of information logged.\r\n(Faster operation on some s" +
@@ -5520,7 +5532,7 @@
             this.CheckForUpdate_checkBox.AutoSize = true;
             this.CheckForUpdate_checkBox.Location = new System.Drawing.Point(6, 612);
             this.CheckForUpdate_checkBox.Name = "CheckForUpdate_checkBox";
-            this.CheckForUpdate_checkBox.Size = new System.Drawing.Size(213, 21);
+            this.CheckForUpdate_checkBox.Size = new System.Drawing.Size(163, 17);
             this.CheckForUpdate_checkBox.TabIndex = 100;
             this.CheckForUpdate_checkBox.Text = "Check for updates on startup";
             this.toolTip1.SetToolTip(this.CheckForUpdate_checkBox, "If checked, reads file http://www.liteplacer.com/Downloads/release.txt\r\nand repor" +
@@ -5533,7 +5545,7 @@
             this.MouseScroll_checkBox.Location = new System.Drawing.Point(1034, 376);
             this.MouseScroll_checkBox.Name = "MouseScroll_checkBox";
             this.MouseScroll_checkBox.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.MouseScroll_checkBox.Size = new System.Drawing.Size(239, 21);
+            this.MouseScroll_checkBox.Size = new System.Drawing.Size(183, 17);
             this.MouseScroll_checkBox.TabIndex = 99;
             this.MouseScroll_checkBox.Text = "Enable mouse wheel jogging of A";
             this.toolTip1.SetToolTip(this.MouseScroll_checkBox, "If enabled, mouse wheel rotates Nozzle");
@@ -5545,7 +5557,7 @@
             this.NumPadJog_checkBox.Location = new System.Drawing.Point(1033, 353);
             this.NumPadJog_checkBox.Name = "NumPadJog_checkBox";
             this.NumPadJog_checkBox.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.NumPadJog_checkBox.Size = new System.Drawing.Size(240, 21);
+            this.NumPadJog_checkBox.Size = new System.Drawing.Size(184, 17);
             this.NumPadJog_checkBox.TabIndex = 98;
             this.NumPadJog_checkBox.Text = "Enable jogging with numpad keys";
             this.toolTip1.SetToolTip(this.NumPadJog_checkBox, "If enabled, numpad keys moe the machine");
@@ -5558,7 +5570,7 @@
             this.Zlb_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.818182F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Zlb_label.Location = new System.Drawing.Point(3, 541);
             this.Zlb_label.Name = "Zlb_label";
-            this.Zlb_label.Size = new System.Drawing.Size(422, 42);
+            this.Zlb_label.Size = new System.Drawing.Size(353, 36);
             this.Zlb_label.TabIndex = 51;
             this.Zlb_label.Text = "Jog Z axis until the Nozzle just barely touches the PCB\r\nthen click \"next\"";
             this.Zlb_label.Visible = false;
@@ -5587,7 +5599,7 @@
             // 
             this.Hysteresis_textBox.Location = new System.Drawing.Point(323, 51);
             this.Hysteresis_textBox.Name = "Hysteresis_textBox";
-            this.Hysteresis_textBox.Size = new System.Drawing.Size(55, 22);
+            this.Hysteresis_textBox.Size = new System.Drawing.Size(55, 20);
             this.Hysteresis_textBox.TabIndex = 103;
             this.Hysteresis_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.Hysteresis_textBox_KeyPress);
             // 
@@ -5596,7 +5608,7 @@
             this.label136.AutoSize = true;
             this.label136.Location = new System.Drawing.Point(226, 54);
             this.label136.Name = "label136";
-            this.label136.Size = new System.Drawing.Size(120, 17);
+            this.label136.Size = new System.Drawing.Size(91, 13);
             this.label136.TabIndex = 102;
             this.label136.Text = "Switch hysteresis:";
             // 
@@ -5604,7 +5616,7 @@
             // 
             this.PlacementDepth_textBox.Location = new System.Drawing.Point(487, 51);
             this.PlacementDepth_textBox.Name = "PlacementDepth_textBox";
-            this.PlacementDepth_textBox.Size = new System.Drawing.Size(55, 22);
+            this.PlacementDepth_textBox.Size = new System.Drawing.Size(55, 20);
             this.PlacementDepth_textBox.TabIndex = 101;
             this.PlacementDepth_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.PlacementDepth_textBox_KeyPress);
             // 
@@ -5613,7 +5625,7 @@
             this.label112.AutoSize = true;
             this.label112.Location = new System.Drawing.Point(391, 54);
             this.label112.Name = "label112";
-            this.label112.Size = new System.Drawing.Size(118, 17);
+            this.label112.Size = new System.Drawing.Size(90, 13);
             this.label112.TabIndex = 100;
             this.label112.Text = "Placement depth:";
             // 
@@ -5621,7 +5633,7 @@
             // 
             this.BackOff_textBox.Location = new System.Drawing.Point(487, 25);
             this.BackOff_textBox.Name = "BackOff_textBox";
-            this.BackOff_textBox.Size = new System.Drawing.Size(55, 22);
+            this.BackOff_textBox.Size = new System.Drawing.Size(55, 20);
             this.BackOff_textBox.TabIndex = 99;
             this.BackOff_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.BackOff_textBox_KeyPress);
             // 
@@ -5629,7 +5641,7 @@
             // 
             this.Z0_textBox.Location = new System.Drawing.Point(323, 25);
             this.Z0_textBox.Name = "Z0_textBox";
-            this.Z0_textBox.Size = new System.Drawing.Size(55, 22);
+            this.Z0_textBox.Size = new System.Drawing.Size(55, 20);
             this.Z0_textBox.TabIndex = 98;
             // 
             // CancelProbing_button
@@ -5650,7 +5662,7 @@
             this.label116.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label116.Location = new System.Drawing.Point(3, 0);
             this.label116.Name = "label116";
-            this.label116.Size = new System.Drawing.Size(224, 20);
+            this.label116.Size = new System.Drawing.Size(182, 16);
             this.label116.TabIndex = 49;
             this.label116.Text = "Nozzle height calibration:";
             // 
@@ -5670,7 +5682,7 @@
             this.label111.AutoSize = true;
             this.label111.Location = new System.Drawing.Point(258, 28);
             this.label111.Name = "label111";
-            this.label111.Size = new System.Drawing.Size(76, 17);
+            this.label111.Size = new System.Drawing.Size(59, 13);
             this.label111.TabIndex = 52;
             this.label111.Text = "Z0 to PCB:";
             // 
@@ -5679,7 +5691,7 @@
             this.label117.AutoSize = true;
             this.label117.Location = new System.Drawing.Point(434, 28);
             this.label117.Name = "label117";
-            this.label117.Size = new System.Drawing.Size(59, 17);
+            this.label117.Size = new System.Drawing.Size(47, 13);
             this.label117.TabIndex = 76;
             this.label117.Text = "Backoff:";
             // 
@@ -5689,7 +5701,7 @@
             this.SlackCompensationA_checkBox.Location = new System.Drawing.Point(1076, 145);
             this.SlackCompensationA_checkBox.Name = "SlackCompensationA_checkBox";
             this.SlackCompensationA_checkBox.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.SlackCompensationA_checkBox.Size = new System.Drawing.Size(183, 21);
+            this.SlackCompensationA_checkBox.Size = new System.Drawing.Size(141, 17);
             this.SlackCompensationA_checkBox.TabIndex = 96;
             this.SlackCompensationA_checkBox.Text = "Slack Compensation, rot";
             this.toolTip1.SetToolTip(this.SlackCompensationA_checkBox, "All rotation movements will go to position from same direction.\r\nIf there is slac" +
@@ -5707,7 +5719,7 @@
             0,
             0});
             this.AltJogSpeed_numericUpDown.Name = "AltJogSpeed_numericUpDown";
-            this.AltJogSpeed_numericUpDown.Size = new System.Drawing.Size(58, 22);
+            this.AltJogSpeed_numericUpDown.Size = new System.Drawing.Size(58, 20);
             this.AltJogSpeed_numericUpDown.TabIndex = 95;
             this.toolTip1.SetToolTip(this.AltJogSpeed_numericUpDown, "Set jog speed");
             this.AltJogSpeed_numericUpDown.Value = new decimal(new int[] {
@@ -5726,7 +5738,7 @@
             0,
             0});
             this.NormalJogSpeed_numericUpDown.Name = "NormalJogSpeed_numericUpDown";
-            this.NormalJogSpeed_numericUpDown.Size = new System.Drawing.Size(58, 22);
+            this.NormalJogSpeed_numericUpDown.Size = new System.Drawing.Size(58, 20);
             this.NormalJogSpeed_numericUpDown.TabIndex = 94;
             this.toolTip1.SetToolTip(this.NormalJogSpeed_numericUpDown, "Set jog speed");
             this.NormalJogSpeed_numericUpDown.Value = new decimal(new int[] {
@@ -5745,7 +5757,7 @@
             0,
             0});
             this.CtlrJogSpeed_numericUpDown.Name = "CtlrJogSpeed_numericUpDown";
-            this.CtlrJogSpeed_numericUpDown.Size = new System.Drawing.Size(58, 22);
+            this.CtlrJogSpeed_numericUpDown.Size = new System.Drawing.Size(58, 20);
             this.CtlrJogSpeed_numericUpDown.TabIndex = 93;
             this.toolTip1.SetToolTip(this.CtlrJogSpeed_numericUpDown, "Set jog speed");
             this.CtlrJogSpeed_numericUpDown.Value = new decimal(new int[] {
@@ -5760,7 +5772,7 @@
             this.label134.AutoSize = true;
             this.label134.Location = new System.Drawing.Point(1080, 329);
             this.label134.Name = "label134";
-            this.label134.Size = new System.Drawing.Size(97, 17);
+            this.label134.Size = new System.Drawing.Size(73, 13);
             this.label134.TabIndex = 91;
             this.label134.Text = "With Alt (fast):";
             this.toolTip1.SetToolTip(this.label134, "Set jog speed");
@@ -5770,7 +5782,7 @@
             this.label133.AutoSize = true;
             this.label133.Location = new System.Drawing.Point(1110, 303);
             this.label133.Name = "label133";
-            this.label133.Size = new System.Drawing.Size(57, 17);
+            this.label133.Size = new System.Drawing.Size(43, 13);
             this.label133.TabIndex = 89;
             this.label133.Text = "Normal:";
             this.toolTip1.SetToolTip(this.label133, "Set jog speed");
@@ -5780,7 +5792,7 @@
             this.label132.AutoSize = true;
             this.label132.Location = new System.Drawing.Point(1019, 255);
             this.label132.Name = "label132";
-            this.label132.Size = new System.Drawing.Size(208, 17);
+            this.label132.Size = new System.Drawing.Size(158, 13);
             this.label132.TabIndex = 88;
             this.label132.Text = "Speed with numpad arrow keys:";
             this.toolTip1.SetToolTip(this.label132, "Set jog speed");
@@ -5790,7 +5802,7 @@
             this.label131.AutoSize = true;
             this.label131.Location = new System.Drawing.Point(1073, 277);
             this.label131.Name = "label131";
-            this.label131.Size = new System.Drawing.Size(106, 17);
+            this.label131.Size = new System.Drawing.Size(80, 13);
             this.label131.TabIndex = 86;
             this.label131.Text = "With Ctrl (slow):";
             this.toolTip1.SetToolTip(this.label131, "Set jog speed");
@@ -5799,7 +5811,7 @@
             // 
             this.ShadeGuard_textBox.Location = new System.Drawing.Point(593, 516);
             this.ShadeGuard_textBox.Name = "ShadeGuard_textBox";
-            this.ShadeGuard_textBox.Size = new System.Drawing.Size(75, 22);
+            this.ShadeGuard_textBox.Size = new System.Drawing.Size(75, 20);
             this.ShadeGuard_textBox.TabIndex = 85;
             this.ShadeGuard_textBox.TextChanged += new System.EventHandler(this.ShadeGuard_textBox_TextChanged);
             // 
@@ -5808,7 +5820,7 @@
             this.label126.AutoSize = true;
             this.label126.Location = new System.Drawing.Point(508, 519);
             this.label126.Name = "label126";
-            this.label126.Size = new System.Drawing.Size(105, 17);
+            this.label126.Size = new System.Drawing.Size(79, 13);
             this.label126.TabIndex = 84;
             this.label126.Text = "Z shade guard:";
             // 
@@ -5817,7 +5829,7 @@
             this.label123.AutoSize = true;
             this.label123.Location = new System.Drawing.Point(517, 493);
             this.label123.Name = "label123";
-            this.label123.Size = new System.Drawing.Size(92, 17);
+            this.label123.Size = new System.Drawing.Size(70, 13);
             this.label123.TabIndex = 83;
             this.label123.Text = "Z Test travel:";
             // 
@@ -5825,7 +5837,7 @@
             // 
             this.ZTestTravel_textBox.Location = new System.Drawing.Point(593, 490);
             this.ZTestTravel_textBox.Name = "ZTestTravel_textBox";
-            this.ZTestTravel_textBox.Size = new System.Drawing.Size(75, 22);
+            this.ZTestTravel_textBox.Size = new System.Drawing.Size(75, 20);
             this.ZTestTravel_textBox.TabIndex = 82;
             this.ZTestTravel_textBox.TextChanged += new System.EventHandler(this.ZTestTravel_textBox_TextChanged);
             // 
@@ -5833,7 +5845,7 @@
             // 
             this.VacuumRelease_textBox.Location = new System.Drawing.Point(1158, 37);
             this.VacuumRelease_textBox.Name = "VacuumRelease_textBox";
-            this.VacuumRelease_textBox.Size = new System.Drawing.Size(58, 22);
+            this.VacuumRelease_textBox.Size = new System.Drawing.Size(58, 20);
             this.VacuumRelease_textBox.TabIndex = 81;
             this.toolTip1.SetToolTip(this.VacuumRelease_textBox, "If set to zero: For each mm of +Y movement, the \r\nmachine moves this much in X. S" +
         "et the value\r\nfor square movement.");
@@ -5845,7 +5857,7 @@
             this.label119.AutoSize = true;
             this.label119.Location = new System.Drawing.Point(1018, 40);
             this.label119.Name = "label119";
-            this.label119.Size = new System.Drawing.Size(176, 17);
+            this.label119.Size = new System.Drawing.Size(130, 13);
             this.label119.TabIndex = 80;
             this.label119.Text = "Vacuum release time (ms):";
             // 
@@ -5853,7 +5865,7 @@
             // 
             this.VacuumTime_textBox.Location = new System.Drawing.Point(1158, 13);
             this.VacuumTime_textBox.Name = "VacuumTime_textBox";
-            this.VacuumTime_textBox.Size = new System.Drawing.Size(58, 22);
+            this.VacuumTime_textBox.Size = new System.Drawing.Size(58, 20);
             this.VacuumTime_textBox.TabIndex = 79;
             this.toolTip1.SetToolTip(this.VacuumTime_textBox, "If set to zero: For each mm of +Y movement, the \r\nmachine moves this much in X. S" +
         "et the value\r\nfor square movement.");
@@ -5865,7 +5877,7 @@
             this.label118.AutoSize = true;
             this.label118.Location = new System.Drawing.Point(1018, 17);
             this.label118.Name = "label118";
-            this.label118.Size = new System.Drawing.Size(169, 17);
+            this.label118.Size = new System.Drawing.Size(128, 13);
             this.label118.TabIndex = 78;
             this.label118.Text = "Pickup vacuum time (ms):";
             // 
@@ -5874,7 +5886,7 @@
             this.label90.AutoSize = true;
             this.label90.Location = new System.Drawing.Point(1019, 220);
             this.label90.Name = "label90";
-            this.label90.Size = new System.Drawing.Size(155, 17);
+            this.label90.Size = new System.Drawing.Size(116, 13);
             this.label90.TabIndex = 74;
             this.label90.Text = "Squareness correction:";
             // 
@@ -5882,7 +5894,7 @@
             // 
             this.SquareCorrection_textBox.Location = new System.Drawing.Point(1141, 217);
             this.SquareCorrection_textBox.Name = "SquareCorrection_textBox";
-            this.SquareCorrection_textBox.Size = new System.Drawing.Size(76, 22);
+            this.SquareCorrection_textBox.Size = new System.Drawing.Size(76, 20);
             this.SquareCorrection_textBox.TabIndex = 73;
             this.toolTip1.SetToolTip(this.SquareCorrection_textBox, "If set to zero: For each mm of +Y movement, the \r\nmachine moves this much in X. S" +
         "et the value\r\nfor square movement.");
@@ -5898,7 +5910,7 @@
             0,
             0});
             this.SmallMovement_numericUpDown.Name = "SmallMovement_numericUpDown";
-            this.SmallMovement_numericUpDown.Size = new System.Drawing.Size(48, 22);
+            this.SmallMovement_numericUpDown.Size = new System.Drawing.Size(48, 20);
             this.SmallMovement_numericUpDown.TabIndex = 72;
             this.toolTip1.SetToolTip(this.SmallMovement_numericUpDown, "To avoid jerkiness, small movements are done\r\nwith smaller speed. That speed is s" +
         "et here.");
@@ -5914,7 +5926,7 @@
             this.label87.AutoSize = true;
             this.label87.Location = new System.Drawing.Point(1062, 196);
             this.label87.Name = "label87";
-            this.label87.Size = new System.Drawing.Size(134, 17);
+            this.label87.Size = new System.Drawing.Size(101, 13);
             this.label87.TabIndex = 71;
             this.label87.Text = "Small moves speed:";
             // 
@@ -5923,17 +5935,17 @@
             this.label152.AutoSize = true;
             this.label152.Location = new System.Drawing.Point(1094, 460);
             this.label152.Name = "label152";
-            this.label152.Size = new System.Drawing.Size(45, 17);
+            this.label152.Size = new System.Drawing.Size(35, 13);
             this.label152.TabIndex = 70;
             this.label152.Text = "Name";
             // 
             // SlackCompensation_checkBox
             // 
             this.SlackCompensation_checkBox.AutoSize = true;
-            this.SlackCompensation_checkBox.Location = new System.Drawing.Point(1069, 168);
+            this.SlackCompensation_checkBox.Location = new System.Drawing.Point(1019, 168);
             this.SlackCompensation_checkBox.Name = "SlackCompensation_checkBox";
             this.SlackCompensation_checkBox.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.SlackCompensation_checkBox.Size = new System.Drawing.Size(188, 21);
+            this.SlackCompensation_checkBox.Size = new System.Drawing.Size(148, 17);
             this.SlackCompensation_checkBox.TabIndex = 57;
             this.SlackCompensation_checkBox.Text = "Slack Compensation, X/Y";
             this.toolTip1.SetToolTip(this.SlackCompensation_checkBox, "All X-Y movements will go to position from same direction.\r\nIf there is slack in " +
@@ -5967,7 +5979,7 @@
             // 
             this.Mark6_textBox.Location = new System.Drawing.Point(1097, 607);
             this.Mark6_textBox.Name = "Mark6_textBox";
-            this.Mark6_textBox.Size = new System.Drawing.Size(133, 22);
+            this.Mark6_textBox.Size = new System.Drawing.Size(133, 20);
             this.Mark6_textBox.TabIndex = 68;
             this.toolTip1.SetToolTip(this.Mark6_textBox, "Sets and names your \"special\" locations.");
             // 
@@ -5975,7 +5987,7 @@
             // 
             this.Mark5_textBox.Location = new System.Drawing.Point(1097, 581);
             this.Mark5_textBox.Name = "Mark5_textBox";
-            this.Mark5_textBox.Size = new System.Drawing.Size(133, 22);
+            this.Mark5_textBox.Size = new System.Drawing.Size(133, 20);
             this.Mark5_textBox.TabIndex = 66;
             this.toolTip1.SetToolTip(this.Mark5_textBox, "Sets and names your \"special\" locations.");
             // 
@@ -5983,7 +5995,7 @@
             // 
             this.Mark4_textBox.Location = new System.Drawing.Point(1097, 555);
             this.Mark4_textBox.Name = "Mark4_textBox";
-            this.Mark4_textBox.Size = new System.Drawing.Size(133, 22);
+            this.Mark4_textBox.Size = new System.Drawing.Size(133, 20);
             this.Mark4_textBox.TabIndex = 64;
             this.toolTip1.SetToolTip(this.Mark4_textBox, "Sets and names your \"special\" locations.");
             // 
@@ -5991,7 +6003,7 @@
             // 
             this.Mark3_textBox.Location = new System.Drawing.Point(1097, 529);
             this.Mark3_textBox.Name = "Mark3_textBox";
-            this.Mark3_textBox.Size = new System.Drawing.Size(133, 22);
+            this.Mark3_textBox.Size = new System.Drawing.Size(133, 20);
             this.Mark3_textBox.TabIndex = 62;
             this.toolTip1.SetToolTip(this.Mark3_textBox, "Sets and names your \"special\" locations.");
             // 
@@ -5999,7 +6011,7 @@
             // 
             this.Mark2_textBox.Location = new System.Drawing.Point(1097, 503);
             this.Mark2_textBox.Name = "Mark2_textBox";
-            this.Mark2_textBox.Size = new System.Drawing.Size(133, 22);
+            this.Mark2_textBox.Size = new System.Drawing.Size(133, 20);
             this.Mark2_textBox.TabIndex = 60;
             this.toolTip1.SetToolTip(this.Mark2_textBox, "Sets and names your \"special\" locations.");
             // 
@@ -6007,7 +6019,7 @@
             // 
             this.SizeYMax_textBox.Location = new System.Drawing.Point(1141, 108);
             this.SizeYMax_textBox.Name = "SizeYMax_textBox";
-            this.SizeYMax_textBox.Size = new System.Drawing.Size(76, 22);
+            this.SizeYMax_textBox.Size = new System.Drawing.Size(76, 20);
             this.SizeYMax_textBox.TabIndex = 44;
             this.toolTip1.SetToolTip(this.SizeYMax_textBox, "Allows for custom machine size");
             this.SizeYMax_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.SizeYMax_textBox_KeyPress);
@@ -6017,7 +6029,7 @@
             // 
             this.Mark1_textBox.Location = new System.Drawing.Point(1097, 477);
             this.Mark1_textBox.Name = "Mark1_textBox";
-            this.Mark1_textBox.Size = new System.Drawing.Size(133, 22);
+            this.Mark1_textBox.Size = new System.Drawing.Size(133, 20);
             this.Mark1_textBox.TabIndex = 58;
             this.toolTip1.SetToolTip(this.Mark1_textBox, "Sets and names your \"special\" locations.");
             // 
@@ -6025,7 +6037,7 @@
             // 
             this.SizeXMax_textBox.Location = new System.Drawing.Point(1141, 82);
             this.SizeXMax_textBox.Name = "SizeXMax_textBox";
-            this.SizeXMax_textBox.Size = new System.Drawing.Size(76, 22);
+            this.SizeXMax_textBox.Size = new System.Drawing.Size(76, 20);
             this.SizeXMax_textBox.TabIndex = 42;
             this.toolTip1.SetToolTip(this.SizeXMax_textBox, "Allows for custom machine size");
             this.SizeXMax_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.SizeXMax_textBox_KeyPress);
@@ -6035,7 +6047,7 @@
             // 
             this.ParkLocationY_textBox.Location = new System.Drawing.Point(1141, 429);
             this.ParkLocationY_textBox.Name = "ParkLocationY_textBox";
-            this.ParkLocationY_textBox.Size = new System.Drawing.Size(76, 22);
+            this.ParkLocationY_textBox.Size = new System.Drawing.Size(76, 20);
             this.ParkLocationY_textBox.TabIndex = 39;
             this.toolTip1.SetToolTip(this.ParkLocationY_textBox, "Define \"Park\" location, where machine\r\ngoes to make room for tape loadings etc.");
             this.ParkLocationY_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.ParkLocationY_textBox_KeyPress);
@@ -6045,7 +6057,7 @@
             // 
             this.ParkLocationX_textBox.Location = new System.Drawing.Point(1141, 403);
             this.ParkLocationX_textBox.Name = "ParkLocationX_textBox";
-            this.ParkLocationX_textBox.Size = new System.Drawing.Size(76, 22);
+            this.ParkLocationX_textBox.Size = new System.Drawing.Size(76, 20);
             this.ParkLocationX_textBox.TabIndex = 37;
             this.toolTip1.SetToolTip(this.ParkLocationX_textBox, "Define \"Park\" location, where machine\r\ngoes to make room for tape loadings etc.");
             this.ParkLocationX_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.ParkLocationX_textBox_KeyPress);
@@ -6078,7 +6090,7 @@
             this.MotorPower_checkBox.AutoSize = true;
             this.MotorPower_checkBox.Location = new System.Drawing.Point(848, 55);
             this.MotorPower_checkBox.Name = "MotorPower_checkBox";
-            this.MotorPower_checkBox.Size = new System.Drawing.Size(109, 21);
+            this.MotorPower_checkBox.Size = new System.Drawing.Size(86, 17);
             this.MotorPower_checkBox.TabIndex = 54;
             this.MotorPower_checkBox.Text = "Motor Power";
             this.toolTip1.SetToolTip(this.MotorPower_checkBox, "Motor power on/off \r\n(Motor power on holds machine position)");
@@ -6123,7 +6135,7 @@
             this.label113.AutoSize = true;
             this.label113.Location = new System.Drawing.Point(1061, 68);
             this.label113.Name = "label113";
-            this.label113.Size = new System.Drawing.Size(96, 17);
+            this.label113.Size = new System.Drawing.Size(74, 13);
             this.label113.TabIndex = 48;
             this.label113.Text = "Machine Size:";
             // 
@@ -6132,7 +6144,7 @@
             this.label102.AutoSize = true;
             this.label102.Location = new System.Drawing.Point(1095, 111);
             this.label102.Name = "label102";
-            this.label102.Size = new System.Drawing.Size(50, 17);
+            this.label102.Size = new System.Drawing.Size(40, 13);
             this.label102.TabIndex = 45;
             this.label102.Text = "Max Y:";
             // 
@@ -6152,7 +6164,7 @@
             this.label107.AutoSize = true;
             this.label107.Location = new System.Drawing.Point(1095, 85);
             this.label107.Name = "label107";
-            this.label107.Size = new System.Drawing.Size(50, 17);
+            this.label107.Size = new System.Drawing.Size(40, 13);
             this.label107.TabIndex = 43;
             this.label107.Text = "Max X:";
             // 
@@ -6161,7 +6173,7 @@
             this.label92.AutoSize = true;
             this.label92.Location = new System.Drawing.Point(1049, 432);
             this.label92.Name = "label92";
-            this.label92.Size = new System.Drawing.Size(112, 17);
+            this.label92.Size = new System.Drawing.Size(86, 13);
             this.label92.TabIndex = 40;
             this.label92.Text = "Park Location Y:";
             // 
@@ -6170,7 +6182,7 @@
             this.label61.AutoSize = true;
             this.label61.Location = new System.Drawing.Point(1049, 406);
             this.label61.Name = "label61";
-            this.label61.Size = new System.Drawing.Size(112, 17);
+            this.label61.Size = new System.Drawing.Size(86, 13);
             this.label61.TabIndex = 38;
             this.label61.Text = "Park Location X:";
             // 
@@ -6179,7 +6191,7 @@
             this.label72.AutoSize = true;
             this.label72.Location = new System.Drawing.Point(822, 487);
             this.label72.Name = "label72";
-            this.label72.Size = new System.Drawing.Size(119, 17);
+            this.label72.Size = new System.Drawing.Size(89, 13);
             this.label72.TabIndex = 36;
             this.label72.Text = "(No homing on A)";
             // 
@@ -6276,7 +6288,7 @@
             this.Vacuum_checkBox.AutoSize = true;
             this.Vacuum_checkBox.Location = new System.Drawing.Point(848, 35);
             this.Vacuum_checkBox.Name = "Vacuum_checkBox";
-            this.Vacuum_checkBox.Size = new System.Drawing.Size(208, 21);
+            this.Vacuum_checkBox.Size = new System.Drawing.Size(159, 17);
             this.Vacuum_checkBox.TabIndex = 26;
             this.Vacuum_checkBox.Text = "Vacuum On (solenoid valve)";
             this.toolTip1.SetToolTip(this.Vacuum_checkBox, "Valve control, vacuum on Nozzle on/off");
@@ -6288,7 +6300,7 @@
             this.Pump_checkBox.AutoSize = true;
             this.Pump_checkBox.Location = new System.Drawing.Point(848, 15);
             this.Pump_checkBox.Name = "Pump_checkBox";
-            this.Pump_checkBox.Size = new System.Drawing.Size(89, 21);
+            this.Pump_checkBox.Size = new System.Drawing.Size(70, 17);
             this.Pump_checkBox.TabIndex = 25;
             this.Pump_checkBox.Text = "Pump On";
             this.toolTip1.SetToolTip(this.Pump_checkBox, "Vacuum pump on/off");
@@ -6367,7 +6379,7 @@
             // 
             this.tr4_textBox.Location = new System.Drawing.Point(101, 84);
             this.tr4_textBox.Name = "tr4_textBox";
-            this.tr4_textBox.Size = new System.Drawing.Size(55, 22);
+            this.tr4_textBox.Size = new System.Drawing.Size(55, 20);
             this.tr4_textBox.TabIndex = 21;
             this.tr4_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.tr4_textBox_KeyPress);
             // 
@@ -6376,7 +6388,7 @@
             this.m4deg18_radioButton.AutoSize = true;
             this.m4deg18_radioButton.Location = new System.Drawing.Point(153, 59);
             this.m4deg18_radioButton.Name = "m4deg18_radioButton";
-            this.m4deg18_radioButton.Size = new System.Drawing.Size(81, 21);
+            this.m4deg18_radioButton.Size = new System.Drawing.Size(64, 17);
             this.m4deg18_radioButton.TabIndex = 28;
             this.m4deg18_radioButton.TabStop = true;
             this.m4deg18_radioButton.Text = "1.8 deg.";
@@ -6388,7 +6400,7 @@
             this.m4deg09_radioButton.AutoSize = true;
             this.m4deg09_radioButton.Location = new System.Drawing.Point(91, 59);
             this.m4deg09_radioButton.Name = "m4deg09_radioButton";
-            this.m4deg09_radioButton.Size = new System.Drawing.Size(81, 21);
+            this.m4deg09_radioButton.Size = new System.Drawing.Size(64, 17);
             this.m4deg09_radioButton.TabIndex = 27;
             this.m4deg09_radioButton.TabStop = true;
             this.m4deg09_radioButton.Text = "0.9 deg.";
@@ -6400,7 +6412,7 @@
             this.label42.AutoSize = true;
             this.label42.Location = new System.Drawing.Point(3, 87);
             this.label42.Name = "label42";
-            this.label42.Size = new System.Drawing.Size(134, 17);
+            this.label42.Size = new System.Drawing.Size(100, 13);
             this.label42.TabIndex = 25;
             this.label42.Text = "Travel per rev. [4tr]:";
             // 
@@ -6409,7 +6421,7 @@
             this.label43.AutoSize = true;
             this.label43.Location = new System.Drawing.Point(162, 87);
             this.label43.Name = "label43";
-            this.label43.Size = new System.Drawing.Size(30, 17);
+            this.label43.Size = new System.Drawing.Size(23, 13);
             this.label43.TabIndex = 24;
             this.label43.Text = "mm";
             // 
@@ -6418,7 +6430,7 @@
             this.label44.AutoSize = true;
             this.label44.Location = new System.Drawing.Point(3, 61);
             this.label44.Name = "label44";
-            this.label44.Size = new System.Drawing.Size(115, 17);
+            this.label44.Size = new System.Drawing.Size(87, 13);
             this.label44.TabIndex = 22;
             this.label44.Text = "Step angle [4sa]:";
             // 
@@ -6429,7 +6441,7 @@
             this.mi4_maskedTextBox.Name = "mi4_maskedTextBox";
             this.mi4_maskedTextBox.PromptChar = ' ';
             this.mi4_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.mi4_maskedTextBox.Size = new System.Drawing.Size(24, 22);
+            this.mi4_maskedTextBox.Size = new System.Drawing.Size(24, 20);
             this.mi4_maskedTextBox.TabIndex = 20;
             this.mi4_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.mi4_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -6440,7 +6452,7 @@
             this.label45.AutoSize = true;
             this.label45.Location = new System.Drawing.Point(3, 35);
             this.label45.Name = "label45";
-            this.label45.Size = new System.Drawing.Size(114, 17);
+            this.label45.Size = new System.Drawing.Size(86, 13);
             this.label45.TabIndex = 19;
             this.label45.Text = "Microsteps [4mi]:";
             // 
@@ -6449,7 +6461,7 @@
             this.Microsteps4_label.AutoSize = true;
             this.Microsteps4_label.Location = new System.Drawing.Point(123, 34);
             this.Microsteps4_label.Name = "Microsteps4_label";
-            this.Microsteps4_label.Size = new System.Drawing.Size(72, 17);
+            this.Microsteps4_label.Size = new System.Drawing.Size(55, 13);
             this.Microsteps4_label.TabIndex = 18;
             this.Microsteps4_label.Text = "[1, 2, 4, 8]";
             // 
@@ -6459,7 +6471,7 @@
             this.label47.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label47.Location = new System.Drawing.Point(3, 8);
             this.label47.Name = "label47";
-            this.label47.Size = new System.Drawing.Size(73, 20);
+            this.label47.Size = new System.Drawing.Size(59, 16);
             this.label47.TabIndex = 15;
             this.label47.Text = "Motor4:";
             // 
@@ -6468,7 +6480,7 @@
             this.label48.AutoSize = true;
             this.label48.Location = new System.Drawing.Point(3, 53);
             this.label48.Name = "label48";
-            this.label48.Size = new System.Drawing.Size(119, 17);
+            this.label48.Size = new System.Drawing.Size(91, 13);
             this.label48.TabIndex = 16;
             this.label48.Text = "Speed [avm, avr]:";
             // 
@@ -6479,7 +6491,7 @@
             this.avm_maskedTextBox.Name = "avm_maskedTextBox";
             this.avm_maskedTextBox.PromptChar = ' ';
             this.avm_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.avm_maskedTextBox.Size = new System.Drawing.Size(43, 22);
+            this.avm_maskedTextBox.Size = new System.Drawing.Size(43, 20);
             this.avm_maskedTextBox.TabIndex = 17;
             this.avm_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.avm_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -6490,7 +6502,7 @@
             this.label49.AutoSize = true;
             this.label49.Location = new System.Drawing.Point(154, 54);
             this.label49.Name = "label49";
-            this.label49.Size = new System.Drawing.Size(86, 17);
+            this.label49.Size = new System.Drawing.Size(67, 13);
             this.label49.TabIndex = 15;
             this.label49.Text = "000 deg/min";
             // 
@@ -6500,7 +6512,7 @@
             this.label50.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label50.Location = new System.Drawing.Point(3, 4);
             this.label50.Name = "label50";
-            this.label50.Size = new System.Drawing.Size(34, 25);
+            this.label50.Size = new System.Drawing.Size(26, 20);
             this.label50.TabIndex = 14;
             this.label50.Text = "A:";
             // 
@@ -6509,7 +6521,7 @@
             this.label51.AutoSize = true;
             this.label51.Location = new System.Drawing.Point(3, 28);
             this.label51.Name = "label51";
-            this.label51.Size = new System.Drawing.Size(97, 17);
+            this.label51.Size = new System.Drawing.Size(74, 13);
             this.label51.TabIndex = 12;
             this.label51.Text = "Acceler. [ajm]:";
             // 
@@ -6520,7 +6532,7 @@
             this.ajm_maskedTextBox.Name = "ajm_maskedTextBox";
             this.ajm_maskedTextBox.PromptChar = ' ';
             this.ajm_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.ajm_maskedTextBox.Size = new System.Drawing.Size(43, 22);
+            this.ajm_maskedTextBox.Size = new System.Drawing.Size(43, 20);
             this.ajm_maskedTextBox.TabIndex = 13;
             this.ajm_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.ajm_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -6531,7 +6543,7 @@
             this.label52.AutoSize = true;
             this.label52.Location = new System.Drawing.Point(151, 27);
             this.label52.Name = "label52";
-            this.label52.Size = new System.Drawing.Size(102, 17);
+            this.label52.Size = new System.Drawing.Size(80, 13);
             this.label52.TabIndex = 11;
             this.label52.Text = "10^6mm/min^3";
             // 
@@ -6566,7 +6578,7 @@
             this.label73.AutoSize = true;
             this.label73.Location = new System.Drawing.Point(3, 189);
             this.label73.Name = "label73";
-            this.label73.Size = new System.Drawing.Size(103, 17);
+            this.label73.Size = new System.Drawing.Size(78, 13);
             this.label73.TabIndex = 26;
             this.label73.Text = "Homing speed:";
             // 
@@ -6577,7 +6589,7 @@
             this.xsv_maskedTextBox.Name = "xsv_maskedTextBox";
             this.xsv_maskedTextBox.PromptChar = ' ';
             this.xsv_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.xsv_maskedTextBox.Size = new System.Drawing.Size(43, 22);
+            this.xsv_maskedTextBox.Size = new System.Drawing.Size(43, 20);
             this.xsv_maskedTextBox.TabIndex = 27;
             this.xsv_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.xsv_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -6588,7 +6600,7 @@
             this.label74.AutoSize = true;
             this.label74.Location = new System.Drawing.Point(161, 189);
             this.label74.Name = "label74";
-            this.label74.Size = new System.Drawing.Size(56, 17);
+            this.label74.Size = new System.Drawing.Size(44, 13);
             this.label74.TabIndex = 25;
             this.label74.Text = "mm/min";
             // 
@@ -6597,7 +6609,7 @@
             this.label75.AutoSize = true;
             this.label75.Location = new System.Drawing.Point(4, 163);
             this.label75.Name = "label75";
-            this.label75.Size = new System.Drawing.Size(141, 17);
+            this.label75.Size = new System.Drawing.Size(107, 13);
             this.label75.TabIndex = 23;
             this.label75.Text = "Homing acceleration:";
             // 
@@ -6608,7 +6620,7 @@
             this.xjh_maskedTextBox.Name = "xjh_maskedTextBox";
             this.xjh_maskedTextBox.PromptChar = ' ';
             this.xjh_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.xjh_maskedTextBox.Size = new System.Drawing.Size(43, 22);
+            this.xjh_maskedTextBox.Size = new System.Drawing.Size(43, 20);
             this.xjh_maskedTextBox.TabIndex = 24;
             this.xjh_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.xjh_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -6619,7 +6631,7 @@
             this.label76.AutoSize = true;
             this.label76.Location = new System.Drawing.Point(159, 163);
             this.label76.Name = "label76";
-            this.label76.Size = new System.Drawing.Size(102, 17);
+            this.label76.Size = new System.Drawing.Size(80, 13);
             this.label76.TabIndex = 22;
             this.label76.Text = "10^6mm/min^3";
             // 
@@ -6628,7 +6640,7 @@
             this.Xmax_checkBox.AutoSize = true;
             this.Xmax_checkBox.Location = new System.Drawing.Point(7, 133);
             this.Xmax_checkBox.Name = "Xmax_checkBox";
-            this.Xmax_checkBox.Size = new System.Drawing.Size(160, 21);
+            this.Xmax_checkBox.Size = new System.Drawing.Size(125, 17);
             this.Xmax_checkBox.TabIndex = 21;
             this.Xmax_checkBox.Text = "Max limit switch used";
             this.Xmax_checkBox.UseVisualStyleBackColor = true;
@@ -6639,7 +6651,7 @@
             this.Xlim_checkBox.AutoSize = true;
             this.Xlim_checkBox.Location = new System.Drawing.Point(7, 110);
             this.Xlim_checkBox.Name = "Xlim_checkBox";
-            this.Xlim_checkBox.Size = new System.Drawing.Size(157, 21);
+            this.Xlim_checkBox.Size = new System.Drawing.Size(122, 17);
             this.Xlim_checkBox.TabIndex = 20;
             this.Xlim_checkBox.Text = "Min limit switch used";
             this.Xlim_checkBox.UseVisualStyleBackColor = true;
@@ -6650,7 +6662,7 @@
             this.Xhome_checkBox.AutoSize = true;
             this.Xhome_checkBox.Location = new System.Drawing.Point(7, 87);
             this.Xhome_checkBox.Name = "Xhome_checkBox";
-            this.Xhome_checkBox.Size = new System.Drawing.Size(155, 21);
+            this.Xhome_checkBox.Size = new System.Drawing.Size(121, 17);
             this.Xhome_checkBox.TabIndex = 19;
             this.Xhome_checkBox.Text = "Homing switch used";
             this.Xhome_checkBox.UseVisualStyleBackColor = true;
@@ -6678,7 +6690,7 @@
             // 
             this.tr1_textBox.Location = new System.Drawing.Point(101, 81);
             this.tr1_textBox.Name = "tr1_textBox";
-            this.tr1_textBox.Size = new System.Drawing.Size(54, 22);
+            this.tr1_textBox.Size = new System.Drawing.Size(54, 20);
             this.tr1_textBox.TabIndex = 19;
             this.tr1_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.tr1_textBox_KeyPress);
             // 
@@ -6687,7 +6699,7 @@
             this.m1deg18_radioButton.AutoSize = true;
             this.m1deg18_radioButton.Location = new System.Drawing.Point(153, 58);
             this.m1deg18_radioButton.Name = "m1deg18_radioButton";
-            this.m1deg18_radioButton.Size = new System.Drawing.Size(81, 21);
+            this.m1deg18_radioButton.Size = new System.Drawing.Size(64, 17);
             this.m1deg18_radioButton.TabIndex = 28;
             this.m1deg18_radioButton.TabStop = true;
             this.m1deg18_radioButton.Text = "1.8 deg.";
@@ -6699,7 +6711,7 @@
             this.m1deg09_radioButton.AutoSize = true;
             this.m1deg09_radioButton.Location = new System.Drawing.Point(91, 58);
             this.m1deg09_radioButton.Name = "m1deg09_radioButton";
-            this.m1deg09_radioButton.Size = new System.Drawing.Size(81, 21);
+            this.m1deg09_radioButton.Size = new System.Drawing.Size(64, 17);
             this.m1deg09_radioButton.TabIndex = 27;
             this.m1deg09_radioButton.TabStop = true;
             this.m1deg09_radioButton.Text = "0.9 deg.";
@@ -6711,7 +6723,7 @@
             this.label20.AutoSize = true;
             this.label20.Location = new System.Drawing.Point(3, 86);
             this.label20.Name = "label20";
-            this.label20.Size = new System.Drawing.Size(134, 17);
+            this.label20.Size = new System.Drawing.Size(100, 13);
             this.label20.TabIndex = 25;
             this.label20.Text = "Travel per rev. [1tr]:";
             // 
@@ -6720,7 +6732,7 @@
             this.label21.AutoSize = true;
             this.label21.Location = new System.Drawing.Point(161, 86);
             this.label21.Name = "label21";
-            this.label21.Size = new System.Drawing.Size(30, 17);
+            this.label21.Size = new System.Drawing.Size(23, 13);
             this.label21.TabIndex = 24;
             this.label21.Text = "mm";
             // 
@@ -6729,7 +6741,7 @@
             this.label22.AutoSize = true;
             this.label22.Location = new System.Drawing.Point(3, 60);
             this.label22.Name = "label22";
-            this.label22.Size = new System.Drawing.Size(115, 17);
+            this.label22.Size = new System.Drawing.Size(87, 13);
             this.label22.TabIndex = 22;
             this.label22.Text = "Step angle [1sa]:";
             // 
@@ -6740,7 +6752,7 @@
             this.mi1_maskedTextBox.Name = "mi1_maskedTextBox";
             this.mi1_maskedTextBox.PromptChar = ' ';
             this.mi1_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.mi1_maskedTextBox.Size = new System.Drawing.Size(24, 22);
+            this.mi1_maskedTextBox.Size = new System.Drawing.Size(24, 20);
             this.mi1_maskedTextBox.TabIndex = 20;
             this.mi1_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.mi1_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -6751,7 +6763,7 @@
             this.Microsteps1_label.AutoSize = true;
             this.Microsteps1_label.Location = new System.Drawing.Point(123, 34);
             this.Microsteps1_label.Name = "Microsteps1_label";
-            this.Microsteps1_label.Size = new System.Drawing.Size(72, 17);
+            this.Microsteps1_label.Size = new System.Drawing.Size(55, 13);
             this.Microsteps1_label.TabIndex = 18;
             this.Microsteps1_label.Text = "[1, 2, 4, 8]";
             // 
@@ -6761,7 +6773,7 @@
             this.label25.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label25.Location = new System.Drawing.Point(3, 8);
             this.label25.Name = "label25";
-            this.label25.Size = new System.Drawing.Size(73, 20);
+            this.label25.Size = new System.Drawing.Size(59, 16);
             this.label25.TabIndex = 15;
             this.label25.Text = "Motor1:";
             // 
@@ -6770,7 +6782,7 @@
             this.label23.AutoSize = true;
             this.label23.Location = new System.Drawing.Point(3, 35);
             this.label23.Name = "label23";
-            this.label23.Size = new System.Drawing.Size(114, 17);
+            this.label23.Size = new System.Drawing.Size(86, 13);
             this.label23.TabIndex = 19;
             this.label23.Text = "Microsteps [1mi]:";
             // 
@@ -6779,7 +6791,7 @@
             this.label26.AutoSize = true;
             this.label26.Location = new System.Drawing.Point(4, 54);
             this.label26.Name = "label26";
-            this.label26.Size = new System.Drawing.Size(112, 17);
+            this.label26.Size = new System.Drawing.Size(86, 13);
             this.label26.TabIndex = 16;
             this.label26.Text = "Speed [xvm, xfr]:";
             // 
@@ -6790,7 +6802,7 @@
             this.xvm_maskedTextBox.Name = "xvm_maskedTextBox";
             this.xvm_maskedTextBox.PromptChar = ' ';
             this.xvm_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.xvm_maskedTextBox.Size = new System.Drawing.Size(43, 22);
+            this.xvm_maskedTextBox.Size = new System.Drawing.Size(43, 20);
             this.xvm_maskedTextBox.TabIndex = 17;
             this.xvm_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.xvm_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -6801,7 +6813,7 @@
             this.label27.AutoSize = true;
             this.label27.Location = new System.Drawing.Point(159, 54);
             this.label27.Name = "label27";
-            this.label27.Size = new System.Drawing.Size(84, 17);
+            this.label27.Size = new System.Drawing.Size(65, 13);
             this.label27.TabIndex = 15;
             this.label27.Text = "000 mm/min";
             // 
@@ -6811,7 +6823,7 @@
             this.label28.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label28.Location = new System.Drawing.Point(3, 4);
             this.label28.Name = "label28";
-            this.label28.Size = new System.Drawing.Size(34, 25);
+            this.label28.Size = new System.Drawing.Size(26, 20);
             this.label28.TabIndex = 14;
             this.label28.Text = "X:";
             // 
@@ -6820,7 +6832,7 @@
             this.label29.AutoSize = true;
             this.label29.Location = new System.Drawing.Point(3, 28);
             this.label29.Name = "label29";
-            this.label29.Size = new System.Drawing.Size(122, 17);
+            this.label29.Size = new System.Drawing.Size(93, 13);
             this.label29.TabIndex = 12;
             this.label29.Text = "Acceleration [xjm]:";
             // 
@@ -6831,7 +6843,7 @@
             this.xjm_maskedTextBox.Name = "xjm_maskedTextBox";
             this.xjm_maskedTextBox.PromptChar = ' ';
             this.xjm_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.xjm_maskedTextBox.Size = new System.Drawing.Size(43, 22);
+            this.xjm_maskedTextBox.Size = new System.Drawing.Size(43, 20);
             this.xjm_maskedTextBox.TabIndex = 13;
             this.xjm_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.xjm_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -6842,7 +6854,7 @@
             this.label30.AutoSize = true;
             this.label30.Location = new System.Drawing.Point(159, 28);
             this.label30.Name = "label30";
-            this.label30.Size = new System.Drawing.Size(102, 17);
+            this.label30.Size = new System.Drawing.Size(80, 13);
             this.label30.TabIndex = 11;
             this.label30.Text = "10^6mm/min^3";
             // 
@@ -6877,7 +6889,7 @@
             this.label81.AutoSize = true;
             this.label81.Location = new System.Drawing.Point(3, 189);
             this.label81.Name = "label81";
-            this.label81.Size = new System.Drawing.Size(103, 17);
+            this.label81.Size = new System.Drawing.Size(78, 13);
             this.label81.TabIndex = 32;
             this.label81.Text = "Homing speed:";
             // 
@@ -6888,7 +6900,7 @@
             this.zsv_maskedTextBox.Name = "zsv_maskedTextBox";
             this.zsv_maskedTextBox.PromptChar = ' ';
             this.zsv_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.zsv_maskedTextBox.Size = new System.Drawing.Size(43, 22);
+            this.zsv_maskedTextBox.Size = new System.Drawing.Size(43, 20);
             this.zsv_maskedTextBox.TabIndex = 33;
             this.zsv_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.zsv_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -6899,7 +6911,7 @@
             this.label82.AutoSize = true;
             this.label82.Location = new System.Drawing.Point(159, 189);
             this.label82.Name = "label82";
-            this.label82.Size = new System.Drawing.Size(56, 17);
+            this.label82.Size = new System.Drawing.Size(44, 13);
             this.label82.TabIndex = 31;
             this.label82.Text = "mm/min";
             // 
@@ -6908,7 +6920,7 @@
             this.label83.AutoSize = true;
             this.label83.Location = new System.Drawing.Point(3, 163);
             this.label83.Name = "label83";
-            this.label83.Size = new System.Drawing.Size(141, 17);
+            this.label83.Size = new System.Drawing.Size(107, 13);
             this.label83.TabIndex = 29;
             this.label83.Text = "Homing acceleration:";
             // 
@@ -6919,7 +6931,7 @@
             this.zjh_maskedTextBox.Name = "zjh_maskedTextBox";
             this.zjh_maskedTextBox.PromptChar = ' ';
             this.zjh_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.zjh_maskedTextBox.Size = new System.Drawing.Size(43, 22);
+            this.zjh_maskedTextBox.Size = new System.Drawing.Size(43, 20);
             this.zjh_maskedTextBox.TabIndex = 30;
             this.zjh_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.zjh_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -6930,7 +6942,7 @@
             this.label84.AutoSize = true;
             this.label84.Location = new System.Drawing.Point(159, 163);
             this.label84.Name = "label84";
-            this.label84.Size = new System.Drawing.Size(102, 17);
+            this.label84.Size = new System.Drawing.Size(80, 13);
             this.label84.TabIndex = 28;
             this.label84.Text = "10^6mm/min^3";
             // 
@@ -6939,7 +6951,7 @@
             this.Zmax_checkBox.AutoSize = true;
             this.Zmax_checkBox.Location = new System.Drawing.Point(7, 133);
             this.Zmax_checkBox.Name = "Zmax_checkBox";
-            this.Zmax_checkBox.Size = new System.Drawing.Size(160, 21);
+            this.Zmax_checkBox.Size = new System.Drawing.Size(125, 17);
             this.Zmax_checkBox.TabIndex = 24;
             this.Zmax_checkBox.Text = "Max limit switch used";
             this.Zmax_checkBox.UseVisualStyleBackColor = true;
@@ -6950,7 +6962,7 @@
             this.Zlim_checkBox.AutoSize = true;
             this.Zlim_checkBox.Location = new System.Drawing.Point(7, 110);
             this.Zlim_checkBox.Name = "Zlim_checkBox";
-            this.Zlim_checkBox.Size = new System.Drawing.Size(157, 21);
+            this.Zlim_checkBox.Size = new System.Drawing.Size(122, 17);
             this.Zlim_checkBox.TabIndex = 23;
             this.Zlim_checkBox.Text = "Min limit switch used";
             this.Zlim_checkBox.UseVisualStyleBackColor = true;
@@ -6961,7 +6973,7 @@
             this.Zhome_checkBox.AutoSize = true;
             this.Zhome_checkBox.Location = new System.Drawing.Point(7, 87);
             this.Zhome_checkBox.Name = "Zhome_checkBox";
-            this.Zhome_checkBox.Size = new System.Drawing.Size(155, 21);
+            this.Zhome_checkBox.Size = new System.Drawing.Size(121, 17);
             this.Zhome_checkBox.TabIndex = 22;
             this.Zhome_checkBox.Text = "Homing switch used";
             this.Zhome_checkBox.UseVisualStyleBackColor = true;
@@ -6989,7 +7001,7 @@
             // 
             this.tr3_textBox.Location = new System.Drawing.Point(101, 84);
             this.tr3_textBox.Name = "tr3_textBox";
-            this.tr3_textBox.Size = new System.Drawing.Size(54, 22);
+            this.tr3_textBox.Size = new System.Drawing.Size(54, 20);
             this.tr3_textBox.TabIndex = 21;
             this.tr3_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.tr3_textBox_KeyPress);
             // 
@@ -6998,7 +7010,7 @@
             this.m3deg18_radioButton.AutoSize = true;
             this.m3deg18_radioButton.Location = new System.Drawing.Point(153, 59);
             this.m3deg18_radioButton.Name = "m3deg18_radioButton";
-            this.m3deg18_radioButton.Size = new System.Drawing.Size(81, 21);
+            this.m3deg18_radioButton.Size = new System.Drawing.Size(64, 17);
             this.m3deg18_radioButton.TabIndex = 28;
             this.m3deg18_radioButton.TabStop = true;
             this.m3deg18_radioButton.Text = "1.8 deg.";
@@ -7010,7 +7022,7 @@
             this.m3deg09_radioButton.AutoSize = true;
             this.m3deg09_radioButton.Location = new System.Drawing.Point(91, 59);
             this.m3deg09_radioButton.Name = "m3deg09_radioButton";
-            this.m3deg09_radioButton.Size = new System.Drawing.Size(81, 21);
+            this.m3deg09_radioButton.Size = new System.Drawing.Size(64, 17);
             this.m3deg09_radioButton.TabIndex = 27;
             this.m3deg09_radioButton.TabStop = true;
             this.m3deg09_radioButton.Text = "0.9 deg.";
@@ -7022,7 +7034,7 @@
             this.label31.AutoSize = true;
             this.label31.Location = new System.Drawing.Point(3, 87);
             this.label31.Name = "label31";
-            this.label31.Size = new System.Drawing.Size(134, 17);
+            this.label31.Size = new System.Drawing.Size(100, 13);
             this.label31.TabIndex = 25;
             this.label31.Text = "Travel per rev. [3tr]:";
             // 
@@ -7031,7 +7043,7 @@
             this.label32.AutoSize = true;
             this.label32.Location = new System.Drawing.Point(161, 87);
             this.label32.Name = "label32";
-            this.label32.Size = new System.Drawing.Size(30, 17);
+            this.label32.Size = new System.Drawing.Size(23, 13);
             this.label32.TabIndex = 24;
             this.label32.Text = "mm";
             // 
@@ -7040,7 +7052,7 @@
             this.label33.AutoSize = true;
             this.label33.Location = new System.Drawing.Point(3, 61);
             this.label33.Name = "label33";
-            this.label33.Size = new System.Drawing.Size(115, 17);
+            this.label33.Size = new System.Drawing.Size(87, 13);
             this.label33.TabIndex = 22;
             this.label33.Text = "Step angle [3sa]:";
             // 
@@ -7051,7 +7063,7 @@
             this.mi3_maskedTextBox.Name = "mi3_maskedTextBox";
             this.mi3_maskedTextBox.PromptChar = ' ';
             this.mi3_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.mi3_maskedTextBox.Size = new System.Drawing.Size(24, 22);
+            this.mi3_maskedTextBox.Size = new System.Drawing.Size(24, 20);
             this.mi3_maskedTextBox.TabIndex = 20;
             this.mi3_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.mi3_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -7062,7 +7074,7 @@
             this.label34.AutoSize = true;
             this.label34.Location = new System.Drawing.Point(3, 35);
             this.label34.Name = "label34";
-            this.label34.Size = new System.Drawing.Size(114, 17);
+            this.label34.Size = new System.Drawing.Size(86, 13);
             this.label34.TabIndex = 19;
             this.label34.Text = "Microsteps [3mi]:";
             // 
@@ -7071,7 +7083,7 @@
             this.Microsteps3_label.AutoSize = true;
             this.Microsteps3_label.Location = new System.Drawing.Point(123, 34);
             this.Microsteps3_label.Name = "Microsteps3_label";
-            this.Microsteps3_label.Size = new System.Drawing.Size(72, 17);
+            this.Microsteps3_label.Size = new System.Drawing.Size(55, 13);
             this.Microsteps3_label.TabIndex = 18;
             this.Microsteps3_label.Text = "[1, 2, 4, 8]";
             // 
@@ -7081,7 +7093,7 @@
             this.label36.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label36.Location = new System.Drawing.Point(3, 8);
             this.label36.Name = "label36";
-            this.label36.Size = new System.Drawing.Size(73, 20);
+            this.label36.Size = new System.Drawing.Size(59, 16);
             this.label36.TabIndex = 15;
             this.label36.Text = "Motor3:";
             // 
@@ -7090,7 +7102,7 @@
             this.label37.AutoSize = true;
             this.label37.Location = new System.Drawing.Point(3, 54);
             this.label37.Name = "label37";
-            this.label37.Size = new System.Drawing.Size(117, 17);
+            this.label37.Size = new System.Drawing.Size(89, 13);
             this.label37.TabIndex = 16;
             this.label37.Text = "Speed [zvm, zvr]:";
             // 
@@ -7101,7 +7113,7 @@
             this.zvm_maskedTextBox.Name = "zvm_maskedTextBox";
             this.zvm_maskedTextBox.PromptChar = ' ';
             this.zvm_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.zvm_maskedTextBox.Size = new System.Drawing.Size(43, 22);
+            this.zvm_maskedTextBox.Size = new System.Drawing.Size(43, 20);
             this.zvm_maskedTextBox.TabIndex = 17;
             this.zvm_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.zvm_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -7112,7 +7124,7 @@
             this.label38.AutoSize = true;
             this.label38.Location = new System.Drawing.Point(159, 54);
             this.label38.Name = "label38";
-            this.label38.Size = new System.Drawing.Size(56, 17);
+            this.label38.Size = new System.Drawing.Size(44, 13);
             this.label38.TabIndex = 15;
             this.label38.Text = "mm/min";
             // 
@@ -7122,7 +7134,7 @@
             this.label39.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label39.Location = new System.Drawing.Point(3, 4);
             this.label39.Name = "label39";
-            this.label39.Size = new System.Drawing.Size(32, 25);
+            this.label39.Size = new System.Drawing.Size(25, 20);
             this.label39.TabIndex = 14;
             this.label39.Text = "Z:";
             // 
@@ -7131,7 +7143,7 @@
             this.label40.AutoSize = true;
             this.label40.Location = new System.Drawing.Point(3, 28);
             this.label40.Name = "label40";
-            this.label40.Size = new System.Drawing.Size(96, 17);
+            this.label40.Size = new System.Drawing.Size(73, 13);
             this.label40.TabIndex = 12;
             this.label40.Text = "Acceler. [zjm]:";
             // 
@@ -7142,7 +7154,7 @@
             this.zjm_maskedTextBox.Name = "zjm_maskedTextBox";
             this.zjm_maskedTextBox.PromptChar = ' ';
             this.zjm_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.zjm_maskedTextBox.Size = new System.Drawing.Size(43, 22);
+            this.zjm_maskedTextBox.Size = new System.Drawing.Size(43, 20);
             this.zjm_maskedTextBox.TabIndex = 13;
             this.zjm_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.zjm_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -7153,7 +7165,7 @@
             this.label41.AutoSize = true;
             this.label41.Location = new System.Drawing.Point(159, 27);
             this.label41.Name = "label41";
-            this.label41.Size = new System.Drawing.Size(102, 17);
+            this.label41.Size = new System.Drawing.Size(80, 13);
             this.label41.TabIndex = 11;
             this.label41.Text = "10^6mm/min^3";
             // 
@@ -7188,7 +7200,7 @@
             this.label77.AutoSize = true;
             this.label77.Location = new System.Drawing.Point(4, 189);
             this.label77.Name = "label77";
-            this.label77.Size = new System.Drawing.Size(103, 17);
+            this.label77.Size = new System.Drawing.Size(78, 13);
             this.label77.TabIndex = 32;
             this.label77.Text = "Homing speed:";
             // 
@@ -7199,7 +7211,7 @@
             this.ysv_maskedTextBox.Name = "ysv_maskedTextBox";
             this.ysv_maskedTextBox.PromptChar = ' ';
             this.ysv_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.ysv_maskedTextBox.Size = new System.Drawing.Size(43, 22);
+            this.ysv_maskedTextBox.Size = new System.Drawing.Size(43, 20);
             this.ysv_maskedTextBox.TabIndex = 33;
             this.ysv_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.ysv_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -7210,7 +7222,7 @@
             this.label78.AutoSize = true;
             this.label78.Location = new System.Drawing.Point(159, 189);
             this.label78.Name = "label78";
-            this.label78.Size = new System.Drawing.Size(56, 17);
+            this.label78.Size = new System.Drawing.Size(44, 13);
             this.label78.TabIndex = 31;
             this.label78.Text = "mm/min";
             // 
@@ -7219,7 +7231,7 @@
             this.label79.AutoSize = true;
             this.label79.Location = new System.Drawing.Point(3, 163);
             this.label79.Name = "label79";
-            this.label79.Size = new System.Drawing.Size(141, 17);
+            this.label79.Size = new System.Drawing.Size(107, 13);
             this.label79.TabIndex = 29;
             this.label79.Text = "Homing acceleration:";
             // 
@@ -7230,7 +7242,7 @@
             this.yjh_maskedTextBox.Name = "yjh_maskedTextBox";
             this.yjh_maskedTextBox.PromptChar = ' ';
             this.yjh_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.yjh_maskedTextBox.Size = new System.Drawing.Size(43, 22);
+            this.yjh_maskedTextBox.Size = new System.Drawing.Size(43, 20);
             this.yjh_maskedTextBox.TabIndex = 30;
             this.yjh_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.yjh_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -7241,7 +7253,7 @@
             this.label80.AutoSize = true;
             this.label80.Location = new System.Drawing.Point(159, 163);
             this.label80.Name = "label80";
-            this.label80.Size = new System.Drawing.Size(102, 17);
+            this.label80.Size = new System.Drawing.Size(80, 13);
             this.label80.TabIndex = 28;
             this.label80.Text = "10^6mm/min^3";
             // 
@@ -7250,7 +7262,7 @@
             this.Ymax_checkBox.AutoSize = true;
             this.Ymax_checkBox.Location = new System.Drawing.Point(7, 133);
             this.Ymax_checkBox.Name = "Ymax_checkBox";
-            this.Ymax_checkBox.Size = new System.Drawing.Size(160, 21);
+            this.Ymax_checkBox.Size = new System.Drawing.Size(125, 17);
             this.Ymax_checkBox.TabIndex = 24;
             this.Ymax_checkBox.Text = "Max limit switch used";
             this.Ymax_checkBox.UseVisualStyleBackColor = true;
@@ -7261,7 +7273,7 @@
             this.Ylim_checkBox.AutoSize = true;
             this.Ylim_checkBox.Location = new System.Drawing.Point(7, 110);
             this.Ylim_checkBox.Name = "Ylim_checkBox";
-            this.Ylim_checkBox.Size = new System.Drawing.Size(157, 21);
+            this.Ylim_checkBox.Size = new System.Drawing.Size(122, 17);
             this.Ylim_checkBox.TabIndex = 23;
             this.Ylim_checkBox.Text = "Min limit switch used";
             this.Ylim_checkBox.UseVisualStyleBackColor = true;
@@ -7272,7 +7284,7 @@
             this.Yhome_checkBox.AutoSize = true;
             this.Yhome_checkBox.Location = new System.Drawing.Point(7, 87);
             this.Yhome_checkBox.Name = "Yhome_checkBox";
-            this.Yhome_checkBox.Size = new System.Drawing.Size(155, 21);
+            this.Yhome_checkBox.Size = new System.Drawing.Size(121, 17);
             this.Yhome_checkBox.TabIndex = 22;
             this.Yhome_checkBox.Text = "Homing switch used";
             this.Yhome_checkBox.UseVisualStyleBackColor = true;
@@ -7300,7 +7312,7 @@
             // 
             this.tr2_textBox.Location = new System.Drawing.Point(101, 81);
             this.tr2_textBox.Name = "tr2_textBox";
-            this.tr2_textBox.Size = new System.Drawing.Size(54, 22);
+            this.tr2_textBox.Size = new System.Drawing.Size(54, 20);
             this.tr2_textBox.TabIndex = 29;
             this.tr2_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.tr2_textBox_KeyPress);
             // 
@@ -7309,7 +7321,7 @@
             this.m2deg18_radioButton.AutoSize = true;
             this.m2deg18_radioButton.Location = new System.Drawing.Point(153, 58);
             this.m2deg18_radioButton.Name = "m2deg18_radioButton";
-            this.m2deg18_radioButton.Size = new System.Drawing.Size(81, 21);
+            this.m2deg18_radioButton.Size = new System.Drawing.Size(64, 17);
             this.m2deg18_radioButton.TabIndex = 28;
             this.m2deg18_radioButton.TabStop = true;
             this.m2deg18_radioButton.Text = "1.8 deg.";
@@ -7321,7 +7333,7 @@
             this.m2deg09_radioButton.AutoSize = true;
             this.m2deg09_radioButton.Location = new System.Drawing.Point(91, 58);
             this.m2deg09_radioButton.Name = "m2deg09_radioButton";
-            this.m2deg09_radioButton.Size = new System.Drawing.Size(81, 21);
+            this.m2deg09_radioButton.Size = new System.Drawing.Size(64, 17);
             this.m2deg09_radioButton.TabIndex = 27;
             this.m2deg09_radioButton.TabStop = true;
             this.m2deg09_radioButton.Text = "0.9 deg.";
@@ -7333,7 +7345,7 @@
             this.label15.AutoSize = true;
             this.label15.Location = new System.Drawing.Point(3, 86);
             this.label15.Name = "label15";
-            this.label15.Size = new System.Drawing.Size(134, 17);
+            this.label15.Size = new System.Drawing.Size(100, 13);
             this.label15.TabIndex = 25;
             this.label15.Text = "Travel per rev. [2tr]:";
             // 
@@ -7342,7 +7354,7 @@
             this.label16.AutoSize = true;
             this.label16.Location = new System.Drawing.Point(161, 86);
             this.label16.Name = "label16";
-            this.label16.Size = new System.Drawing.Size(30, 17);
+            this.label16.Size = new System.Drawing.Size(23, 13);
             this.label16.TabIndex = 24;
             this.label16.Text = "mm";
             // 
@@ -7351,7 +7363,7 @@
             this.label13.AutoSize = true;
             this.label13.Location = new System.Drawing.Point(3, 60);
             this.label13.Name = "label13";
-            this.label13.Size = new System.Drawing.Size(115, 17);
+            this.label13.Size = new System.Drawing.Size(87, 13);
             this.label13.TabIndex = 22;
             this.label13.Text = "Step angle [2sa]:";
             // 
@@ -7363,7 +7375,7 @@
             this.mi2_maskedTextBox.PromptChar = ' ';
             this.mi2_maskedTextBox.ResetOnPrompt = false;
             this.mi2_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.mi2_maskedTextBox.Size = new System.Drawing.Size(24, 22);
+            this.mi2_maskedTextBox.Size = new System.Drawing.Size(24, 20);
             this.mi2_maskedTextBox.TabIndex = 20;
             this.mi2_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.mi2_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -7374,7 +7386,7 @@
             this.Microsteps2_label.AutoSize = true;
             this.Microsteps2_label.Location = new System.Drawing.Point(123, 34);
             this.Microsteps2_label.Name = "Microsteps2_label";
-            this.Microsteps2_label.Size = new System.Drawing.Size(72, 17);
+            this.Microsteps2_label.Size = new System.Drawing.Size(55, 13);
             this.Microsteps2_label.TabIndex = 18;
             this.Microsteps2_label.Text = "[1, 2, 4, 8]";
             // 
@@ -7384,7 +7396,7 @@
             this.label10.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label10.Location = new System.Drawing.Point(3, 8);
             this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(73, 20);
+            this.label10.Size = new System.Drawing.Size(59, 16);
             this.label10.TabIndex = 15;
             this.label10.Text = "Motor2:";
             // 
@@ -7393,7 +7405,7 @@
             this.label11.AutoSize = true;
             this.label11.Location = new System.Drawing.Point(3, 34);
             this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(114, 17);
+            this.label11.Size = new System.Drawing.Size(86, 13);
             this.label11.TabIndex = 19;
             this.label11.Text = "Microsteps [2mi]:";
             // 
@@ -7402,7 +7414,7 @@
             this.label8.AutoSize = true;
             this.label8.Location = new System.Drawing.Point(3, 54);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(114, 17);
+            this.label8.Size = new System.Drawing.Size(86, 13);
             this.label8.TabIndex = 16;
             this.label8.Text = "Speed [yvm, yfr]:";
             // 
@@ -7413,7 +7425,7 @@
             this.yvm_maskedTextBox.Name = "yvm_maskedTextBox";
             this.yvm_maskedTextBox.PromptChar = ' ';
             this.yvm_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.yvm_maskedTextBox.Size = new System.Drawing.Size(43, 22);
+            this.yvm_maskedTextBox.Size = new System.Drawing.Size(43, 20);
             this.yvm_maskedTextBox.TabIndex = 17;
             this.yvm_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.yvm_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -7424,7 +7436,7 @@
             this.label9.AutoSize = true;
             this.label9.Location = new System.Drawing.Point(159, 53);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(84, 17);
+            this.label9.Size = new System.Drawing.Size(65, 13);
             this.label9.TabIndex = 15;
             this.label9.Text = "000 mm/min";
             // 
@@ -7434,7 +7446,7 @@
             this.label7.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label7.Location = new System.Drawing.Point(3, 4);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(33, 25);
+            this.label7.Size = new System.Drawing.Size(26, 20);
             this.label7.TabIndex = 14;
             this.label7.Text = "Y:";
             // 
@@ -7443,7 +7455,7 @@
             this.label6.AutoSize = true;
             this.label6.Location = new System.Drawing.Point(3, 28);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(123, 17);
+            this.label6.Size = new System.Drawing.Size(93, 13);
             this.label6.TabIndex = 12;
             this.label6.Text = "Acceleration [yjm]:";
             // 
@@ -7454,7 +7466,7 @@
             this.yjm_maskedTextBox.Name = "yjm_maskedTextBox";
             this.yjm_maskedTextBox.PromptChar = ' ';
             this.yjm_maskedTextBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.yjm_maskedTextBox.Size = new System.Drawing.Size(43, 22);
+            this.yjm_maskedTextBox.Size = new System.Drawing.Size(43, 20);
             this.yjm_maskedTextBox.TabIndex = 13;
             this.yjm_maskedTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.yjm_maskedTextBox.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
@@ -7465,7 +7477,7 @@
             this.label5.AutoSize = true;
             this.label5.Location = new System.Drawing.Point(159, 27);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(102, 17);
+            this.label5.Size = new System.Drawing.Size(80, 13);
             this.label5.TabIndex = 11;
             this.label5.Text = "10^6mm/min^3";
             // 
@@ -7474,7 +7486,7 @@
             this.label3.AutoSize = true;
             this.label3.Location = new System.Drawing.Point(11, 72);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(52, 17);
+            this.label3.Size = new System.Drawing.Size(40, 13);
             this.label3.TabIndex = 5;
             this.label3.Text = "Status:";
             // 
@@ -7495,7 +7507,7 @@
             this.labelSerialPortStatus.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.labelSerialPortStatus.Location = new System.Drawing.Point(72, 69);
             this.labelSerialPortStatus.Name = "labelSerialPortStatus";
-            this.labelSerialPortStatus.Size = new System.Drawing.Size(134, 24);
+            this.labelSerialPortStatus.Size = new System.Drawing.Size(105, 18);
             this.labelSerialPortStatus.TabIndex = 3;
             this.labelSerialPortStatus.Text = "Not connected";
             this.toolTip1.SetToolTip(this.labelSerialPortStatus, "Connection status");
@@ -7517,7 +7529,7 @@
             this.label2.AutoSize = true;
             this.label2.Location = new System.Drawing.Point(11, 17);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(78, 17);
+            this.label2.Size = new System.Drawing.Size(58, 13);
             this.label2.TabIndex = 1;
             this.label2.Text = "Serial Port:";
             // 
@@ -7527,7 +7539,7 @@
             this.comboBoxSerialPorts.FormattingEnabled = true;
             this.comboBoxSerialPorts.Location = new System.Drawing.Point(75, 14);
             this.comboBoxSerialPorts.Name = "comboBoxSerialPorts";
-            this.comboBoxSerialPorts.Size = new System.Drawing.Size(75, 24);
+            this.comboBoxSerialPorts.Size = new System.Drawing.Size(75, 21);
             this.comboBoxSerialPorts.TabIndex = 0;
             this.toolTip1.SetToolTip(this.comboBoxSerialPorts, "Serial port used by TinyG");
             // 
@@ -7581,10 +7593,10 @@
             this.RunJob_tabPage.Controls.Add(this.label56);
             this.RunJob_tabPage.Controls.Add(this.CadFileName_label);
             this.RunJob_tabPage.Controls.Add(this.CAD_label);
-            this.RunJob_tabPage.Location = new System.Drawing.Point(4, 25);
+            this.RunJob_tabPage.Location = new System.Drawing.Point(4, 22);
             this.RunJob_tabPage.Name = "RunJob_tabPage";
             this.RunJob_tabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.RunJob_tabPage.Size = new System.Drawing.Size(1245, 632);
+            this.RunJob_tabPage.Size = new System.Drawing.Size(1245, 635);
             this.RunJob_tabPage.TabIndex = 2;
             this.RunJob_tabPage.Text = "Run Job";
             this.RunJob_tabPage.UseVisualStyleBackColor = true;
@@ -7616,7 +7628,7 @@
             this.SkipMeasurements_checkBox.AutoSize = true;
             this.SkipMeasurements_checkBox.Location = new System.Drawing.Point(482, 565);
             this.SkipMeasurements_checkBox.Name = "SkipMeasurements_checkBox";
-            this.SkipMeasurements_checkBox.Size = new System.Drawing.Size(231, 21);
+            this.SkipMeasurements_checkBox.Size = new System.Drawing.Size(175, 17);
             this.SkipMeasurements_checkBox.TabIndex = 81;
             this.SkipMeasurements_checkBox.Text = "Skip measurement, use nominal";
             this.SkipMeasurements_checkBox.UseVisualStyleBackColor = true;
@@ -7627,7 +7639,7 @@
             this.OmitNozzleCalibration_checkBox.AutoSize = true;
             this.OmitNozzleCalibration_checkBox.Location = new System.Drawing.Point(482, 584);
             this.OmitNozzleCalibration_checkBox.Name = "OmitNozzleCalibration_checkBox";
-            this.OmitNozzleCalibration_checkBox.Size = new System.Drawing.Size(204, 21);
+            this.OmitNozzleCalibration_checkBox.Size = new System.Drawing.Size(156, 17);
             this.OmitNozzleCalibration_checkBox.TabIndex = 80;
             this.OmitNozzleCalibration_checkBox.Text = "Don\'t use Nozzle correction";
             this.toolTip1.SetToolTip(this.OmitNozzleCalibration_checkBox, "Skips Nozzle correction phase.");
@@ -7639,7 +7651,7 @@
             this.MeasureZs_checkBox.AutoSize = true;
             this.MeasureZs_checkBox.Location = new System.Drawing.Point(482, 603);
             this.MeasureZs_checkBox.Name = "MeasureZs_checkBox";
-            this.MeasureZs_checkBox.Size = new System.Drawing.Size(135, 21);
+            this.MeasureZs_checkBox.Size = new System.Drawing.Size(104, 17);
             this.MeasureZs_checkBox.TabIndex = 79;
             this.MeasureZs_checkBox.Text = "Measure heights";
             this.toolTip1.SetToolTip(this.MeasureZs_checkBox, "If checked, pickup/place heights are measured. If not, existing values are used.");
@@ -7664,7 +7676,7 @@
             this.label127.AutoSize = true;
             this.label127.Location = new System.Drawing.Point(6, 72);
             this.label127.Name = "label127";
-            this.label127.Size = new System.Drawing.Size(125, 17);
+            this.label127.Size = new System.Drawing.Size(93, 13);
             this.label127.TabIndex = 79;
             this.label127.Text = "(Rebuild Job data)";
             // 
@@ -7777,7 +7789,7 @@
             this.ValidMeasurement_checkBox.AutoSize = true;
             this.ValidMeasurement_checkBox.Location = new System.Drawing.Point(482, 546);
             this.ValidMeasurement_checkBox.Name = "ValidMeasurement_checkBox";
-            this.ValidMeasurement_checkBox.Size = new System.Drawing.Size(181, 21);
+            this.ValidMeasurement_checkBox.Size = new System.Drawing.Size(138, 17);
             this.ValidMeasurement_checkBox.TabIndex = 71;
             this.ValidMeasurement_checkBox.Text = "Measurements are valid";
             this.ValidMeasurement_checkBox.UseVisualStyleBackColor = true;
@@ -7788,7 +7800,7 @@
             this.NextGroup_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.NextGroup_label.Location = new System.Drawing.Point(455, 523);
             this.NextGroup_label.Name = "NextGroup_label";
-            this.NextGroup_label.Size = new System.Drawing.Size(21, 20);
+            this.NextGroup_label.Size = new System.Drawing.Size(16, 16);
             this.NextGroup_label.TabIndex = 70;
             this.NextGroup_label.Text = "--";
             // 
@@ -7798,7 +7810,7 @@
             this.label125.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label125.Location = new System.Drawing.Point(352, 524);
             this.label125.Name = "label125";
-            this.label125.Size = new System.Drawing.Size(48, 20);
+            this.label125.Size = new System.Drawing.Size(38, 16);
             this.label125.TabIndex = 69;
             this.label125.Text = "Next:";
             // 
@@ -7808,7 +7820,7 @@
             this.PreviousGroup_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.PreviousGroup_label.Location = new System.Drawing.Point(455, 490);
             this.PreviousGroup_label.Name = "PreviousGroup_label";
-            this.PreviousGroup_label.Size = new System.Drawing.Size(21, 20);
+            this.PreviousGroup_label.Size = new System.Drawing.Size(16, 16);
             this.PreviousGroup_label.TabIndex = 68;
             this.PreviousGroup_label.Text = "--";
             // 
@@ -7830,7 +7842,7 @@
             this.label122.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label122.Location = new System.Drawing.Point(352, 491);
             this.label122.Name = "label122";
-            this.label122.Size = new System.Drawing.Size(79, 20);
+            this.label122.Size = new System.Drawing.Size(64, 16);
             this.label122.TabIndex = 67;
             this.label122.Text = "Previous:";
             // 
@@ -7840,7 +7852,7 @@
             this.CurrentGroup_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.CurrentGroup_label.Location = new System.Drawing.Point(455, 507);
             this.CurrentGroup_label.Name = "CurrentGroup_label";
-            this.CurrentGroup_label.Size = new System.Drawing.Size(21, 20);
+            this.CurrentGroup_label.Size = new System.Drawing.Size(16, 16);
             this.CurrentGroup_label.TabIndex = 66;
             this.CurrentGroup_label.Text = "--";
             // 
@@ -7850,7 +7862,7 @@
             this.label57.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label57.Location = new System.Drawing.Point(352, 508);
             this.label57.Name = "label57";
-            this.label57.Size = new System.Drawing.Size(105, 20);
+            this.label57.Size = new System.Drawing.Size(85, 16);
             this.label57.TabIndex = 65;
             this.label57.Text = "Now placing:";
             // 
@@ -7860,7 +7872,7 @@
             this.JobFilePath_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.JobFilePath_label.Location = new System.Drawing.Point(904, 340);
             this.JobFilePath_label.Name = "JobFilePath_label";
-            this.JobFilePath_label.Size = new System.Drawing.Size(28, 17);
+            this.JobFilePath_label.Size = new System.Drawing.Size(19, 13);
             this.JobFilePath_label.TabIndex = 64;
             this.JobFilePath_label.Text = "----";
             // 
@@ -7870,7 +7882,7 @@
             this.label91.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label91.Location = new System.Drawing.Point(866, 340);
             this.label91.Name = "label91";
-            this.label91.Size = new System.Drawing.Size(41, 17);
+            this.label91.Size = new System.Drawing.Size(32, 13);
             this.label91.TabIndex = 63;
             this.label91.Text = "Path:";
             // 
@@ -7880,7 +7892,7 @@
             this.JobFileName_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.JobFileName_label.Location = new System.Drawing.Point(968, 307);
             this.JobFileName_label.Name = "JobFileName_label";
-            this.JobFileName_label.Size = new System.Drawing.Size(34, 24);
+            this.JobFileName_label.Size = new System.Drawing.Size(28, 18);
             this.JobFileName_label.TabIndex = 62;
             this.JobFileName_label.Text = "----";
             // 
@@ -7890,7 +7902,7 @@
             this.Job_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Job_label.Location = new System.Drawing.Point(865, 310);
             this.Job_label.Name = "Job_label";
-            this.Job_label.Size = new System.Drawing.Size(97, 24);
+            this.Job_label.Size = new System.Drawing.Size(75, 18);
             this.Job_label.TabIndex = 61;
             this.Job_label.Text = "FileName:";
             // 
@@ -7985,7 +7997,7 @@
             this.JobCounterCW_checkBox.Location = new System.Drawing.Point(1122, 41);
             this.JobCounterCW_checkBox.Name = "JobCounterCW_checkBox";
             this.JobCounterCW_checkBox.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.JobCounterCW_checkBox.Size = new System.Drawing.Size(155, 21);
+            this.JobCounterCW_checkBox.Size = new System.Drawing.Size(120, 17);
             this.JobCounterCW_checkBox.TabIndex = 55;
             this.JobCounterCW_checkBox.Text = "Data is Counter-CW";
             this.JobCounterCW_checkBox.UseVisualStyleBackColor = true;
@@ -7995,7 +8007,7 @@
             // 
             this.RotationOffset_textBox.Location = new System.Drawing.Point(1189, 16);
             this.RotationOffset_textBox.Name = "RotationOffset_textBox";
-            this.RotationOffset_textBox.Size = new System.Drawing.Size(43, 22);
+            this.RotationOffset_textBox.Size = new System.Drawing.Size(43, 20);
             this.RotationOffset_textBox.TabIndex = 54;
             this.RotationOffset_textBox.Text = "0.0";
             this.RotationOffset_textBox.Visible = false;
@@ -8004,7 +8016,7 @@
             // 
             this.JobOffsetY_textBox.Location = new System.Drawing.Point(1007, 280);
             this.JobOffsetY_textBox.Name = "JobOffsetY_textBox";
-            this.JobOffsetY_textBox.Size = new System.Drawing.Size(43, 22);
+            this.JobOffsetY_textBox.Size = new System.Drawing.Size(43, 20);
             this.JobOffsetY_textBox.TabIndex = 39;
             this.JobOffsetY_textBox.Text = "0.0";
             this.JobOffsetY_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.JobOffsetY_textBox_KeyPress);
@@ -8014,7 +8026,7 @@
             // 
             this.JobOffsetX_textBox.Location = new System.Drawing.Point(864, 280);
             this.JobOffsetX_textBox.Name = "JobOffsetX_textBox";
-            this.JobOffsetX_textBox.Size = new System.Drawing.Size(43, 22);
+            this.JobOffsetX_textBox.Size = new System.Drawing.Size(43, 20);
             this.JobOffsetX_textBox.TabIndex = 37;
             this.JobOffsetX_textBox.Text = "0.0";
             this.JobOffsetX_textBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.JobOffsetX_textBox_KeyPress);
@@ -8027,7 +8039,7 @@
             this.label60.ForeColor = System.Drawing.Color.DarkRed;
             this.label60.Location = new System.Drawing.Point(1107, 20);
             this.label60.Name = "label60";
-            this.label60.Size = new System.Drawing.Size(103, 17);
+            this.label60.Size = new System.Drawing.Size(78, 13);
             this.label60.TabIndex = 53;
             this.label60.Text = "Job Offset Rot:";
             this.label60.Visible = false;
@@ -8197,7 +8209,7 @@
             this.MachineCoords_label.AutoSize = true;
             this.MachineCoords_label.Location = new System.Drawing.Point(121, 124);
             this.MachineCoords_label.Name = "MachineCoords_label";
-            this.MachineCoords_label.Size = new System.Drawing.Size(18, 17);
+            this.MachineCoords_label.Size = new System.Drawing.Size(13, 13);
             this.MachineCoords_label.TabIndex = 34;
             this.MachineCoords_label.Text = "--";
             // 
@@ -8206,7 +8218,7 @@
             this.PlacedValue_label.AutoSize = true;
             this.PlacedValue_label.Location = new System.Drawing.Point(210, 40);
             this.PlacedValue_label.Name = "PlacedValue_label";
-            this.PlacedValue_label.Size = new System.Drawing.Size(18, 17);
+            this.PlacedValue_label.Size = new System.Drawing.Size(13, 13);
             this.PlacedValue_label.TabIndex = 33;
             this.PlacedValue_label.Text = "--";
             // 
@@ -8215,7 +8227,7 @@
             this.PlacedRotation_label.AutoSize = true;
             this.PlacedRotation_label.Location = new System.Drawing.Point(210, 103);
             this.PlacedRotation_label.Name = "PlacedRotation_label";
-            this.PlacedRotation_label.Size = new System.Drawing.Size(18, 17);
+            this.PlacedRotation_label.Size = new System.Drawing.Size(13, 13);
             this.PlacedRotation_label.TabIndex = 32;
             this.PlacedRotation_label.Text = "--";
             // 
@@ -8224,7 +8236,7 @@
             this.PlacedY_label.AutoSize = true;
             this.PlacedY_label.Location = new System.Drawing.Point(210, 82);
             this.PlacedY_label.Name = "PlacedY_label";
-            this.PlacedY_label.Size = new System.Drawing.Size(18, 17);
+            this.PlacedY_label.Size = new System.Drawing.Size(13, 13);
             this.PlacedY_label.TabIndex = 31;
             this.PlacedY_label.Text = "--";
             // 
@@ -8233,7 +8245,7 @@
             this.PlacedX_label.AutoSize = true;
             this.PlacedX_label.Location = new System.Drawing.Point(210, 61);
             this.PlacedX_label.Name = "PlacedX_label";
-            this.PlacedX_label.Size = new System.Drawing.Size(18, 17);
+            this.PlacedX_label.Size = new System.Drawing.Size(13, 13);
             this.PlacedX_label.TabIndex = 30;
             this.PlacedX_label.Text = "--";
             // 
@@ -8242,7 +8254,7 @@
             this.PlacedComponent_label.AutoSize = true;
             this.PlacedComponent_label.Location = new System.Drawing.Point(210, 19);
             this.PlacedComponent_label.Name = "PlacedComponent_label";
-            this.PlacedComponent_label.Size = new System.Drawing.Size(18, 17);
+            this.PlacedComponent_label.Size = new System.Drawing.Size(13, 13);
             this.PlacedComponent_label.TabIndex = 29;
             this.PlacedComponent_label.Text = "--";
             // 
@@ -8251,7 +8263,7 @@
             this.label66.AutoSize = true;
             this.label66.Location = new System.Drawing.Point(121, 40);
             this.label66.Name = "label66";
-            this.label66.Size = new System.Drawing.Size(115, 17);
+            this.label66.Size = new System.Drawing.Size(86, 13);
             this.label66.TabIndex = 28;
             this.label66.Text = "Value | Footprint:";
             // 
@@ -8260,7 +8272,7 @@
             this.label65.AutoSize = true;
             this.label65.Location = new System.Drawing.Point(121, 103);
             this.label65.Name = "label65";
-            this.label65.Size = new System.Drawing.Size(65, 17);
+            this.label65.Size = new System.Drawing.Size(50, 13);
             this.label65.TabIndex = 27;
             this.label65.Text = "Rotation:";
             // 
@@ -8269,7 +8281,7 @@
             this.label64.AutoSize = true;
             this.label64.Location = new System.Drawing.Point(121, 82);
             this.label64.Name = "label64";
-            this.label64.Size = new System.Drawing.Size(84, 17);
+            this.label64.Size = new System.Drawing.Size(62, 13);
             this.label64.TabIndex = 26;
             this.label64.Text = "Y (nominal):";
             // 
@@ -8278,7 +8290,7 @@
             this.label63.AutoSize = true;
             this.label63.Location = new System.Drawing.Point(121, 61);
             this.label63.Name = "label63";
-            this.label63.Size = new System.Drawing.Size(84, 17);
+            this.label63.Size = new System.Drawing.Size(62, 13);
             this.label63.TabIndex = 25;
             this.label63.Text = "X (nominal):";
             // 
@@ -8287,7 +8299,7 @@
             this.label58.AutoSize = true;
             this.label58.Location = new System.Drawing.Point(121, 19);
             this.label58.Name = "label58";
-            this.label58.Size = new System.Drawing.Size(88, 17);
+            this.label58.Size = new System.Drawing.Size(69, 13);
             this.label58.TabIndex = 23;
             this.label58.Text = "Now placing:";
             // 
@@ -8308,7 +8320,7 @@
             this.label89.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label89.Location = new System.Drawing.Point(657, 286);
             this.label89.Name = "label89";
-            this.label89.Size = new System.Drawing.Size(88, 24);
+            this.label89.Size = new System.Drawing.Size(72, 18);
             this.label89.TabIndex = 44;
             this.label89.Text = "Job Data:";
             this.toolTip1.SetToolTip(this.label89, "The placement operations are done according\r\nto Job Data specifications.");
@@ -8319,7 +8331,7 @@
             this.label88.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label88.Location = new System.Drawing.Point(659, 13);
             this.label88.Name = "label88";
-            this.label88.Size = new System.Drawing.Size(96, 24);
+            this.label88.Size = new System.Drawing.Size(78, 18);
             this.label88.TabIndex = 43;
             this.label88.Text = "CAD Data:";
             // 
@@ -8328,7 +8340,7 @@
             this.label86.AutoSize = true;
             this.label86.Location = new System.Drawing.Point(925, 286);
             this.label86.Name = "label86";
-            this.label86.Size = new System.Drawing.Size(90, 17);
+            this.label86.Size = new System.Drawing.Size(68, 13);
             this.label86.TabIndex = 40;
             this.label86.Text = "Job Offset Y:";
             // 
@@ -8337,7 +8349,7 @@
             this.label85.AutoSize = true;
             this.label85.Location = new System.Drawing.Point(782, 286);
             this.label85.Name = "label85";
-            this.label85.Size = new System.Drawing.Size(90, 17);
+            this.label85.Size = new System.Drawing.Size(68, 13);
             this.label85.TabIndex = 38;
             this.label85.Text = "Job Offset X:";
             // 
@@ -8346,14 +8358,14 @@
             this.JobData_GridView.AllowUserToAddRows = false;
             this.JobData_GridView.AllowUserToResizeRows = false;
             this.JobData_GridView.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableWithoutHeaderText;
-            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
-            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.JobData_GridView.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
+            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle4.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F);
+            dataGridViewCellStyle4.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle4.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle4.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.JobData_GridView.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle4;
             this.JobData_GridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.JobData_GridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.ComponentCount,
@@ -8417,7 +8429,7 @@
             this.Bottom_checkBox.Location = new System.Drawing.Point(663, 37);
             this.Bottom_checkBox.Name = "Bottom_checkBox";
             this.Bottom_checkBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.Bottom_checkBox.Size = new System.Drawing.Size(74, 21);
+            this.Bottom_checkBox.Size = new System.Drawing.Size(59, 17);
             this.Bottom_checkBox.TabIndex = 8;
             this.Bottom_checkBox.Text = "Bottom";
             this.Bottom_checkBox.UseVisualStyleBackColor = true;
@@ -8468,7 +8480,7 @@
             this.Placed_column.HeaderText = "Placed";
             this.Placed_column.Name = "Placed_column";
             this.Placed_column.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.Placed_column.Width = 80;
+            this.Placed_column.Width = 65;
             // 
             // X_nominal
             // 
@@ -8511,13 +8523,13 @@
             this.RunJob_contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.resetPlacedDataToolStripMenuItem});
             this.RunJob_contextMenuStrip.Name = "RunJob_contextMenuStrip";
-            this.RunJob_contextMenuStrip.Size = new System.Drawing.Size(209, 28);
+            this.RunJob_contextMenuStrip.Size = new System.Drawing.Size(177, 26);
             this.RunJob_contextMenuStrip.Text = "Reset \"Placed\" data";
             // 
             // resetPlacedDataToolStripMenuItem
             // 
             this.resetPlacedDataToolStripMenuItem.Name = "resetPlacedDataToolStripMenuItem";
-            this.resetPlacedDataToolStripMenuItem.Size = new System.Drawing.Size(208, 24);
+            this.resetPlacedDataToolStripMenuItem.Size = new System.Drawing.Size(176, 22);
             this.resetPlacedDataToolStripMenuItem.Text = "Reset \"Placed\" data";
             this.resetPlacedDataToolStripMenuItem.Click += new System.EventHandler(this.resetPlacedDataToolStripMenuItem_Click);
             // 
@@ -8527,7 +8539,7 @@
             this.CadFilePath_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.CadFilePath_label.Location = new System.Drawing.Point(904, 38);
             this.CadFilePath_label.Name = "CadFilePath_label";
-            this.CadFilePath_label.Size = new System.Drawing.Size(28, 17);
+            this.CadFilePath_label.Size = new System.Drawing.Size(19, 13);
             this.CadFilePath_label.TabIndex = 3;
             this.CadFilePath_label.Text = "----";
             // 
@@ -8537,7 +8549,7 @@
             this.label56.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label56.Location = new System.Drawing.Point(866, 38);
             this.label56.Name = "label56";
-            this.label56.Size = new System.Drawing.Size(41, 17);
+            this.label56.Size = new System.Drawing.Size(32, 13);
             this.label56.TabIndex = 2;
             this.label56.Text = "Path:";
             // 
@@ -8547,7 +8559,7 @@
             this.CadFileName_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.CadFileName_label.Location = new System.Drawing.Point(968, 10);
             this.CadFileName_label.Name = "CadFileName_label";
-            this.CadFileName_label.Size = new System.Drawing.Size(34, 24);
+            this.CadFileName_label.Size = new System.Drawing.Size(28, 18);
             this.CadFileName_label.TabIndex = 1;
             this.CadFileName_label.Text = "----";
             // 
@@ -8557,7 +8569,7 @@
             this.CAD_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.CAD_label.Location = new System.Drawing.Point(865, 10);
             this.CAD_label.Name = "CAD_label";
-            this.CAD_label.Size = new System.Drawing.Size(97, 24);
+            this.CAD_label.Size = new System.Drawing.Size(75, 18);
             this.CAD_label.TabIndex = 0;
             this.CAD_label.Text = "FileName:";
             // 
@@ -8609,10 +8621,10 @@
             this.Nozzles_tabPage.Controls.Add(this.NoOfNozzles_UpDown);
             this.Nozzles_tabPage.Controls.Add(this.label54);
             this.Nozzles_tabPage.Controls.Add(this.NozzlesLoad_dataGridView);
-            this.Nozzles_tabPage.Location = new System.Drawing.Point(4, 25);
+            this.Nozzles_tabPage.Location = new System.Drawing.Point(4, 22);
             this.Nozzles_tabPage.Name = "Nozzles_tabPage";
             this.Nozzles_tabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.Nozzles_tabPage.Size = new System.Drawing.Size(1245, 632);
+            this.Nozzles_tabPage.Size = new System.Drawing.Size(1245, 635);
             this.Nozzles_tabPage.TabIndex = 7;
             this.Nozzles_tabPage.Text = "Nozzles Setup";
             this.Nozzles_tabPage.UseVisualStyleBackColor = true;
@@ -8622,7 +8634,7 @@
             this.DefaultNozzle_label.AutoSize = true;
             this.DefaultNozzle_label.Location = new System.Drawing.Point(1163, 163);
             this.DefaultNozzle_label.Name = "DefaultNozzle_label";
-            this.DefaultNozzle_label.Size = new System.Drawing.Size(16, 17);
+            this.DefaultNozzle_label.Size = new System.Drawing.Size(13, 13);
             this.DefaultNozzle_label.TabIndex = 44;
             this.DefaultNozzle_label.Text = "1";
             // 
@@ -8631,7 +8643,7 @@
             this.label139.AutoSize = true;
             this.label139.Location = new System.Drawing.Point(1082, 163);
             this.label139.Name = "label139";
-            this.label139.Size = new System.Drawing.Size(106, 17);
+            this.label139.Size = new System.Drawing.Size(80, 13);
             this.label139.TabIndex = 43;
             this.label139.Text = "Default nozzle: ";
             // 
@@ -8639,7 +8651,7 @@
             // 
             this.NozzleWarning_textBox.Location = new System.Drawing.Point(1066, 443);
             this.NozzleWarning_textBox.Name = "NozzleWarning_textBox";
-            this.NozzleWarning_textBox.Size = new System.Drawing.Size(88, 22);
+            this.NozzleWarning_textBox.Size = new System.Drawing.Size(88, 20);
             this.NozzleWarning_textBox.TabIndex = 32;
             this.NozzleWarning_textBox.TextChanged += new System.EventHandler(this.NozzleWarning_textBox_TextChanged);
             // 
@@ -8648,7 +8660,7 @@
             this.label156.AutoSize = true;
             this.label156.Location = new System.Drawing.Point(970, 446);
             this.label156.Name = "label156";
-            this.label156.Size = new System.Drawing.Size(128, 17);
+            this.label156.Size = new System.Drawing.Size(96, 13);
             this.label156.TabIndex = 42;
             this.label156.Text = "Warning threshold:";
             // 
@@ -8667,7 +8679,7 @@
             this.label155.AutoSize = true;
             this.label155.Location = new System.Drawing.Point(971, 586);
             this.label155.Name = "label155";
-            this.label155.Size = new System.Drawing.Size(135, 17);
+            this.label155.Size = new System.Drawing.Size(100, 13);
             this.label155.TabIndex = 40;
             this.label155.Text = "For troubleshooting:";
             // 
@@ -8686,7 +8698,7 @@
             this.label151.AutoSize = true;
             this.label151.Location = new System.Drawing.Point(1141, 131);
             this.label151.Name = "label151";
-            this.label151.Size = new System.Drawing.Size(93, 17);
+            this.label151.Size = new System.Drawing.Size(69, 13);
             this.label151.TabIndex = 38;
             this.label151.Text = "(0=unloaded)";
             // 
@@ -8695,7 +8707,7 @@
             this.label150.AutoSize = true;
             this.label150.Location = new System.Drawing.Point(679, 304);
             this.label150.Name = "label150";
-            this.label150.Size = new System.Drawing.Size(127, 17);
+            this.label150.Size = new System.Drawing.Size(94, 13);
             this.label150.TabIndex = 37;
             this.label150.Text = "Vision Parameters:";
             // 
@@ -8766,33 +8778,33 @@
             this.getUnloadMovesFromLoadMovesToolStripMenuItem,
             this.copyMovesFromNozzle1ToolStripMenuItem});
             this.NozzleUnload_contextMenuStrip.Name = "NozzleUnload_contextMenuStrip";
-            this.NozzleUnload_contextMenuStrip.Size = new System.Drawing.Size(426, 100);
+            this.NozzleUnload_contextMenuStrip.Size = new System.Drawing.Size(352, 92);
             // 
             // gotoUnloadStartToolStripMenuItem
             // 
             this.gotoUnloadStartToolStripMenuItem.Name = "gotoUnloadStartToolStripMenuItem";
-            this.gotoUnloadStartToolStripMenuItem.Size = new System.Drawing.Size(425, 24);
+            this.gotoUnloadStartToolStripMenuItem.Size = new System.Drawing.Size(351, 22);
             this.gotoUnloadStartToolStripMenuItem.Text = "Goto start position";
             this.gotoUnloadStartToolStripMenuItem.Click += new System.EventHandler(this.gotoUnloadStartToolStripMenuItem_Click);
             // 
             // copyUnloadStartPositionsFromLoadEndPositionsToolStripMenuItem
             // 
             this.copyUnloadStartPositionsFromLoadEndPositionsToolStripMenuItem.Name = "copyUnloadStartPositionsFromLoadEndPositionsToolStripMenuItem";
-            this.copyUnloadStartPositionsFromLoadEndPositionsToolStripMenuItem.Size = new System.Drawing.Size(425, 24);
+            this.copyUnloadStartPositionsFromLoadEndPositionsToolStripMenuItem.Size = new System.Drawing.Size(351, 22);
             this.copyUnloadStartPositionsFromLoadEndPositionsToolStripMenuItem.Text = "Copy unload start positions from Load end positions";
             this.copyUnloadStartPositionsFromLoadEndPositionsToolStripMenuItem.Click += new System.EventHandler(this.copyUnloadStartPositionsFromLoadEndPositionsToolStripMenuItem_Click);
             // 
             // getUnloadMovesFromLoadMovesToolStripMenuItem
             // 
             this.getUnloadMovesFromLoadMovesToolStripMenuItem.Name = "getUnloadMovesFromLoadMovesToolStripMenuItem";
-            this.getUnloadMovesFromLoadMovesToolStripMenuItem.Size = new System.Drawing.Size(425, 24);
+            this.getUnloadMovesFromLoadMovesToolStripMenuItem.Size = new System.Drawing.Size(351, 22);
             this.getUnloadMovesFromLoadMovesToolStripMenuItem.Text = "get unload moves from load moves";
             this.getUnloadMovesFromLoadMovesToolStripMenuItem.Click += new System.EventHandler(this.getUnloadMovesFromLoadMovesToolStripMenuItem_Click);
             // 
             // copyMovesFromNozzle1ToolStripMenuItem
             // 
             this.copyMovesFromNozzle1ToolStripMenuItem.Name = "copyMovesFromNozzle1ToolStripMenuItem";
-            this.copyMovesFromNozzle1ToolStripMenuItem.Size = new System.Drawing.Size(425, 24);
+            this.copyMovesFromNozzle1ToolStripMenuItem.Size = new System.Drawing.Size(351, 22);
             this.copyMovesFromNozzle1ToolStripMenuItem.Text = "Copy moves from nozzle 1";
             this.copyMovesFromNozzle1ToolStripMenuItem.Click += new System.EventHandler(this.copyUnloadMovesFromNozzle1_ToolStripMenuItem_Click);
             // 
@@ -8832,7 +8844,7 @@
             this.NozzleChangeEnable_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.NozzleChangeEnable_checkBox.Location = new System.Drawing.Point(971, 534);
             this.NozzleChangeEnable_checkBox.Name = "NozzleChangeEnable_checkBox";
-            this.NozzleChangeEnable_checkBox.Size = new System.Drawing.Size(248, 29);
+            this.NozzleChangeEnable_checkBox.Size = new System.Drawing.Size(205, 24);
             this.NozzleChangeEnable_checkBox.TabIndex = 32;
             this.NozzleChangeEnable_checkBox.Text = "Nozzle change enable";
             this.NozzleChangeEnable_checkBox.UseVisualStyleBackColor = true;
@@ -8866,7 +8878,7 @@
             this.LastMoveFullSpeed_checkBox.AutoSize = true;
             this.LastMoveFullSpeed_checkBox.Location = new System.Drawing.Point(59, 182);
             this.LastMoveFullSpeed_checkBox.Name = "LastMoveFullSpeed_checkBox";
-            this.LastMoveFullSpeed_checkBox.Size = new System.Drawing.Size(160, 21);
+            this.LastMoveFullSpeed_checkBox.Size = new System.Drawing.Size(123, 17);
             this.LastMoveFullSpeed_checkBox.TabIndex = 31;
             this.LastMoveFullSpeed_checkBox.Text = "Last move full speed";
             this.LastMoveFullSpeed_checkBox.UseVisualStyleBackColor = true;
@@ -8877,7 +8889,7 @@
             this.Nozzle1stMoveSlackComp_checkBox.AutoSize = true;
             this.Nozzle1stMoveSlackComp_checkBox.Location = new System.Drawing.Point(59, 136);
             this.Nozzle1stMoveSlackComp_checkBox.Name = "Nozzle1stMoveSlackComp_checkBox";
-            this.Nozzle1stMoveSlackComp_checkBox.Size = new System.Drawing.Size(220, 21);
+            this.Nozzle1stMoveSlackComp_checkBox.Size = new System.Drawing.Size(169, 17);
             this.Nozzle1stMoveSlackComp_checkBox.TabIndex = 30;
             this.Nozzle1stMoveSlackComp_checkBox.Text = "First move slack compensated";
             this.Nozzle1stMoveSlackComp_checkBox.UseVisualStyleBackColor = true;
@@ -8888,7 +8900,7 @@
             this.FirstMoveFullSpeed_checkBox.AutoSize = true;
             this.FirstMoveFullSpeed_checkBox.Location = new System.Drawing.Point(59, 159);
             this.FirstMoveFullSpeed_checkBox.Name = "FirstMoveFullSpeed_checkBox";
-            this.FirstMoveFullSpeed_checkBox.Size = new System.Drawing.Size(160, 21);
+            this.FirstMoveFullSpeed_checkBox.Size = new System.Drawing.Size(122, 17);
             this.FirstMoveFullSpeed_checkBox.TabIndex = 29;
             this.FirstMoveFullSpeed_checkBox.Text = "First move full speed";
             this.FirstMoveFullSpeed_checkBox.UseVisualStyleBackColor = true;
@@ -8899,7 +8911,7 @@
             this.label145.AutoSize = true;
             this.label145.Location = new System.Drawing.Point(5, 113);
             this.label145.Name = "label145";
-            this.label145.Size = new System.Drawing.Size(63, 17);
+            this.label145.Size = new System.Drawing.Size(48, 13);
             this.label145.TabIndex = 28;
             this.label145.Text = "Timeout:";
             // 
@@ -8907,7 +8919,7 @@
             // 
             this.NozzleTimeout_textBox.Location = new System.Drawing.Point(59, 110);
             this.NozzleTimeout_textBox.Name = "NozzleTimeout_textBox";
-            this.NozzleTimeout_textBox.Size = new System.Drawing.Size(70, 22);
+            this.NozzleTimeout_textBox.Size = new System.Drawing.Size(70, 20);
             this.NozzleTimeout_textBox.TabIndex = 27;
             this.NozzleTimeout_textBox.TextChanged += new System.EventHandler(this.NozzleTimeout_textBox_TextChanged);
             // 
@@ -8916,7 +8928,7 @@
             this.NozzleAFullSpeed_checkBox.AutoSize = true;
             this.NozzleAFullSpeed_checkBox.Location = new System.Drawing.Point(135, 86);
             this.NozzleAFullSpeed_checkBox.Name = "NozzleAFullSpeed_checkBox";
-            this.NozzleAFullSpeed_checkBox.Size = new System.Drawing.Size(95, 21);
+            this.NozzleAFullSpeed_checkBox.Size = new System.Drawing.Size(74, 17);
             this.NozzleAFullSpeed_checkBox.TabIndex = 26;
             this.NozzleAFullSpeed_checkBox.Text = "Full speed";
             this.NozzleAFullSpeed_checkBox.UseVisualStyleBackColor = true;
@@ -8927,7 +8939,7 @@
             this.NozzleZFullSpeed_checkBox.AutoSize = true;
             this.NozzleZFullSpeed_checkBox.Location = new System.Drawing.Point(135, 59);
             this.NozzleZFullSpeed_checkBox.Name = "NozzleZFullSpeed_checkBox";
-            this.NozzleZFullSpeed_checkBox.Size = new System.Drawing.Size(95, 21);
+            this.NozzleZFullSpeed_checkBox.Size = new System.Drawing.Size(74, 17);
             this.NozzleZFullSpeed_checkBox.TabIndex = 25;
             this.NozzleZFullSpeed_checkBox.Text = "Full speed";
             this.NozzleZFullSpeed_checkBox.UseVisualStyleBackColor = true;
@@ -8938,7 +8950,7 @@
             this.NozzleXYFullSpeed_checkBox.AutoSize = true;
             this.NozzleXYFullSpeed_checkBox.Location = new System.Drawing.Point(135, 35);
             this.NozzleXYFullSpeed_checkBox.Name = "NozzleXYFullSpeed_checkBox";
-            this.NozzleXYFullSpeed_checkBox.Size = new System.Drawing.Size(95, 21);
+            this.NozzleXYFullSpeed_checkBox.Size = new System.Drawing.Size(74, 17);
             this.NozzleXYFullSpeed_checkBox.TabIndex = 24;
             this.NozzleXYFullSpeed_checkBox.Text = "Full speed";
             this.NozzleXYFullSpeed_checkBox.UseVisualStyleBackColor = true;
@@ -8949,7 +8961,7 @@
             this.label144.AutoSize = true;
             this.label144.Location = new System.Drawing.Point(36, 87);
             this.label144.Name = "label144";
-            this.label144.Size = new System.Drawing.Size(21, 17);
+            this.label144.Size = new System.Drawing.Size(17, 13);
             this.label144.TabIndex = 23;
             this.label144.Text = "A:";
             // 
@@ -8957,7 +8969,7 @@
             // 
             this.NozzleAspeed_textBox.Location = new System.Drawing.Point(59, 84);
             this.NozzleAspeed_textBox.Name = "NozzleAspeed_textBox";
-            this.NozzleAspeed_textBox.Size = new System.Drawing.Size(70, 22);
+            this.NozzleAspeed_textBox.Size = new System.Drawing.Size(70, 20);
             this.NozzleAspeed_textBox.TabIndex = 22;
             this.NozzleAspeed_textBox.TextChanged += new System.EventHandler(this.NozzleAspeed_textBox_TextChanged);
             // 
@@ -8966,7 +8978,7 @@
             this.label142.AutoSize = true;
             this.label142.Location = new System.Drawing.Point(36, 60);
             this.label142.Name = "label142";
-            this.label142.Size = new System.Drawing.Size(21, 17);
+            this.label142.Size = new System.Drawing.Size(17, 13);
             this.label142.TabIndex = 21;
             this.label142.Text = "Z:";
             // 
@@ -8974,7 +8986,7 @@
             // 
             this.NozzleZspeed_textBox.Location = new System.Drawing.Point(59, 58);
             this.NozzleZspeed_textBox.Name = "NozzleZspeed_textBox";
-            this.NozzleZspeed_textBox.Size = new System.Drawing.Size(70, 22);
+            this.NozzleZspeed_textBox.Size = new System.Drawing.Size(70, 20);
             this.NozzleZspeed_textBox.TabIndex = 20;
             this.NozzleZspeed_textBox.TextChanged += new System.EventHandler(this.NozzleZspeed_textBox_TextChanged);
             // 
@@ -8983,7 +8995,7 @@
             this.label141.AutoSize = true;
             this.label141.Location = new System.Drawing.Point(23, 35);
             this.label141.Name = "label141";
-            this.label141.Size = new System.Drawing.Size(38, 17);
+            this.label141.Size = new System.Drawing.Size(30, 13);
             this.label141.TabIndex = 19;
             this.label141.Text = "X, Y:";
             // 
@@ -8991,7 +9003,7 @@
             // 
             this.NozzleXYspeed_textBox.Location = new System.Drawing.Point(59, 32);
             this.NozzleXYspeed_textBox.Name = "NozzleXYspeed_textBox";
-            this.NozzleXYspeed_textBox.Size = new System.Drawing.Size(70, 22);
+            this.NozzleXYspeed_textBox.Size = new System.Drawing.Size(70, 20);
             this.NozzleXYspeed_textBox.TabIndex = 18;
             this.NozzleXYspeed_textBox.TextChanged += new System.EventHandler(this.NozzleXYspeed_textBox_TextChanged);
             // 
@@ -9001,7 +9013,7 @@
             this.label140.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label140.Location = new System.Drawing.Point(3, 9);
             this.label140.Name = "label140";
-            this.label140.Size = new System.Drawing.Size(77, 20);
+            this.label140.Size = new System.Drawing.Size(66, 16);
             this.label140.TabIndex = 17;
             this.label140.Text = "Speeds:";
             // 
@@ -9032,7 +9044,7 @@
             this.NozzleZGuard_checkBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.NozzleZGuard_checkBox.Location = new System.Drawing.Point(1088, 75);
             this.NozzleZGuard_checkBox.Name = "NozzleZGuard_checkBox";
-            this.NozzleZGuard_checkBox.Size = new System.Drawing.Size(100, 21);
+            this.NozzleZGuard_checkBox.Size = new System.Drawing.Size(78, 17);
             this.NozzleZGuard_checkBox.TabIndex = 13;
             this.NozzleZGuard_checkBox.Text = "Z guard off";
             this.NozzleZGuard_checkBox.UseVisualStyleBackColor = true;
@@ -9067,7 +9079,7 @@
             0,
             0});
             this.ForceNozzle_numericUpDown.Name = "ForceNozzle_numericUpDown";
-            this.ForceNozzle_numericUpDown.Size = new System.Drawing.Size(34, 22);
+            this.ForceNozzle_numericUpDown.Size = new System.Drawing.Size(34, 20);
             this.ForceNozzle_numericUpDown.TabIndex = 9;
             this.ForceNozzle_numericUpDown.Value = new decimal(new int[] {
             6,
@@ -9080,7 +9092,7 @@
             this.label124.AutoSize = true;
             this.label124.Location = new System.Drawing.Point(1082, 105);
             this.label124.Name = "label124";
-            this.label124.Size = new System.Drawing.Size(79, 17);
+            this.label124.Size = new System.Drawing.Size(59, 13);
             this.label124.TabIndex = 8;
             this.label124.Text = "(no moves)";
             // 
@@ -9109,7 +9121,7 @@
             this.label97.AutoSize = true;
             this.label97.Location = new System.Drawing.Point(6, 304);
             this.label97.Name = "label97";
-            this.label97.Size = new System.Drawing.Size(57, 17);
+            this.label97.Size = new System.Drawing.Size(44, 13);
             this.label97.TabIndex = 5;
             this.label97.Text = "Unload:";
             // 
@@ -9182,7 +9194,7 @@
             this.label59.AutoSize = true;
             this.label59.Location = new System.Drawing.Point(3, 15);
             this.label59.Name = "label59";
-            this.label59.Size = new System.Drawing.Size(44, 17);
+            this.label59.Size = new System.Drawing.Size(34, 13);
             this.label59.TabIndex = 3;
             this.label59.Text = "Load:";
             // 
@@ -9195,7 +9207,7 @@
             0,
             0});
             this.NoOfNozzles_UpDown.Name = "NoOfNozzles_UpDown";
-            this.NoOfNozzles_UpDown.Size = new System.Drawing.Size(34, 22);
+            this.NoOfNozzles_UpDown.Size = new System.Drawing.Size(34, 20);
             this.NoOfNozzles_UpDown.TabIndex = 2;
             this.NoOfNozzles_UpDown.Value = new decimal(new int[] {
             6,
@@ -9209,7 +9221,7 @@
             this.label54.AutoSize = true;
             this.label54.Location = new System.Drawing.Point(964, 20);
             this.label54.Name = "label54";
-            this.label54.Size = new System.Drawing.Size(216, 17);
+            this.label54.Size = new System.Drawing.Size(160, 13);
             this.label54.TabIndex = 1;
             this.label54.Text = "Number of nozzles in your setup:";
             // 
@@ -9280,19 +9292,19 @@
             this.gotoLoadStartPositionToolStripMenuItem,
             this.copyMovesFromNozzle1ToolStripMenuItem1});
             this.NozzleLoad_contextMenuStrip.Name = "NozzleLoad_contextMenuStrip";
-            this.NozzleLoad_contextMenuStrip.Size = new System.Drawing.Size(255, 52);
+            this.NozzleLoad_contextMenuStrip.Size = new System.Drawing.Size(215, 48);
             // 
             // gotoLoadStartPositionToolStripMenuItem
             // 
             this.gotoLoadStartPositionToolStripMenuItem.Name = "gotoLoadStartPositionToolStripMenuItem";
-            this.gotoLoadStartPositionToolStripMenuItem.Size = new System.Drawing.Size(254, 24);
+            this.gotoLoadStartPositionToolStripMenuItem.Size = new System.Drawing.Size(214, 22);
             this.gotoLoadStartPositionToolStripMenuItem.Text = "Goto start position";
             this.gotoLoadStartPositionToolStripMenuItem.Click += new System.EventHandler(this.gotoStartPositionToolStripMenuItem_Click);
             // 
             // copyMovesFromNozzle1ToolStripMenuItem1
             // 
             this.copyMovesFromNozzle1ToolStripMenuItem1.Name = "copyMovesFromNozzle1ToolStripMenuItem1";
-            this.copyMovesFromNozzle1ToolStripMenuItem1.Size = new System.Drawing.Size(254, 24);
+            this.copyMovesFromNozzle1ToolStripMenuItem1.Size = new System.Drawing.Size(214, 22);
             this.copyMovesFromNozzle1ToolStripMenuItem1.Text = "Copy moves from nozzle 1";
             this.copyMovesFromNozzle1ToolStripMenuItem1.Click += new System.EventHandler(this.copyLoadMovesFromNozzle1_ToolStripMenuItem_Click);
             // 
@@ -9314,7 +9326,7 @@
             this.GotoX_textBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
             this.GotoX_textBox.Location = new System.Drawing.Point(1086, 670);
             this.GotoX_textBox.Name = "GotoX_textBox";
-            this.GotoX_textBox.Size = new System.Drawing.Size(50, 23);
+            this.GotoX_textBox.Size = new System.Drawing.Size(50, 20);
             this.GotoX_textBox.TabIndex = 78;
             this.GotoX_textBox.Text = "0.0";
             this.GotoX_textBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
@@ -9325,7 +9337,7 @@
             this.GotoY_textBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
             this.GotoY_textBox.Location = new System.Drawing.Point(1086, 697);
             this.GotoY_textBox.Name = "GotoY_textBox";
-            this.GotoY_textBox.Size = new System.Drawing.Size(50, 23);
+            this.GotoY_textBox.Size = new System.Drawing.Size(50, 20);
             this.GotoY_textBox.TabIndex = 83;
             this.GotoY_textBox.Text = "0.0";
             this.GotoY_textBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
@@ -9336,7 +9348,7 @@
             this.GotoZ_textBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
             this.GotoZ_textBox.Location = new System.Drawing.Point(1084, 723);
             this.GotoZ_textBox.Name = "GotoZ_textBox";
-            this.GotoZ_textBox.Size = new System.Drawing.Size(50, 23);
+            this.GotoZ_textBox.Size = new System.Drawing.Size(50, 20);
             this.GotoZ_textBox.TabIndex = 85;
             this.GotoZ_textBox.Text = "0.0";
             this.GotoZ_textBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
@@ -9347,7 +9359,7 @@
             this.GotoA_textBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
             this.GotoA_textBox.Location = new System.Drawing.Point(1084, 751);
             this.GotoA_textBox.Name = "GotoA_textBox";
-            this.GotoA_textBox.Size = new System.Drawing.Size(50, 23);
+            this.GotoA_textBox.Size = new System.Drawing.Size(50, 20);
             this.GotoA_textBox.TabIndex = 87;
             this.GotoA_textBox.Text = "0.0";
             this.GotoA_textBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
@@ -9373,7 +9385,7 @@
             this.NozzleNo_textBox.Name = "NozzleNo_textBox";
             this.NozzleNo_textBox.ReadOnly = true;
             this.NozzleNo_textBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.NozzleNo_textBox.Size = new System.Drawing.Size(49, 21);
+            this.NozzleNo_textBox.Size = new System.Drawing.Size(49, 17);
             this.NozzleNo_textBox.TabIndex = 96;
             this.NozzleNo_textBox.Text = "-";
             this.NozzleNo_textBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
@@ -9407,7 +9419,7 @@
             this.TrueX_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.TrueX_label.Location = new System.Drawing.Point(760, 675);
             this.TrueX_label.Name = "TrueX_label";
-            this.TrueX_label.Size = new System.Drawing.Size(46, 13);
+            this.TrueX_label.Size = new System.Drawing.Size(31, 9);
             this.TrueX_label.TabIndex = 77;
             this.TrueX_label.Text = "000.000";
             this.TrueX_label.Visible = false;
@@ -9432,7 +9444,7 @@
             this.Abs_radioButton.Checked = true;
             this.Abs_radioButton.Location = new System.Drawing.Point(958, 672);
             this.Abs_radioButton.Name = "Abs_radioButton";
-            this.Abs_radioButton.Size = new System.Drawing.Size(84, 21);
+            this.Abs_radioButton.Size = new System.Drawing.Size(66, 17);
             this.Abs_radioButton.TabIndex = 92;
             this.Abs_radioButton.TabStop = true;
             this.Abs_radioButton.Text = "Absolute";
@@ -9443,7 +9455,7 @@
             this.Relative_Button.AutoSize = true;
             this.Relative_Button.Location = new System.Drawing.Point(959, 696);
             this.Relative_Button.Name = "Relative_Button";
-            this.Relative_Button.Size = new System.Drawing.Size(80, 21);
+            this.Relative_Button.Size = new System.Drawing.Size(64, 17);
             this.Relative_Button.TabIndex = 93;
             this.Relative_Button.Text = "Relative";
             this.Relative_Button.UseVisualStyleBackColor = true;
@@ -9454,7 +9466,7 @@
             this.label108.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.944F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label108.Location = new System.Drawing.Point(611, 749);
             this.label108.Name = "label108";
-            this.label108.Size = new System.Drawing.Size(77, 24);
+            this.label108.Size = new System.Drawing.Size(63, 18);
             this.label108.TabIndex = 95;
             this.label108.Text = "nozzle:";
             // 
@@ -9516,7 +9528,7 @@
             this.VigorousHoming_checkBox.AutoSize = true;
             this.VigorousHoming_checkBox.Location = new System.Drawing.Point(444, 829);
             this.VigorousHoming_checkBox.Name = "VigorousHoming_checkBox";
-            this.VigorousHoming_checkBox.Size = new System.Drawing.Size(138, 21);
+            this.VigorousHoming_checkBox.Size = new System.Drawing.Size(106, 17);
             this.VigorousHoming_checkBox.TabIndex = 110;
             this.VigorousHoming_checkBox.Text = "Vigorous Homing";
             this.VigorousHoming_checkBox.UseVisualStyleBackColor = true;
@@ -9527,7 +9539,7 @@
             this.label164.AutoSize = true;
             this.label164.Location = new System.Drawing.Point(444, 698);
             this.label164.Name = "label164";
-            this.label164.Size = new System.Drawing.Size(92, 17);
+            this.label164.Size = new System.Drawing.Size(70, 13);
             this.label164.TabIndex = 112;
             this.label164.Text = "Zoom Factor:";
             // 
@@ -9536,7 +9548,7 @@
             this.label165.AutoSize = true;
             this.label165.Location = new System.Drawing.Point(444, 750);
             this.label165.Name = "label165";
-            this.label165.Size = new System.Drawing.Size(92, 17);
+            this.label165.Size = new System.Drawing.Size(70, 13);
             this.label165.TabIndex = 113;
             this.label165.Text = "Zoom Factor:";
             // 
@@ -10491,6 +10503,7 @@
         public System.Windows.Forms.CheckBox VacuumInvert_checkBox;
         public System.Windows.Forms.CheckBox PumpInvert_checkBox;
         private System.Windows.Forms.Button Ato0_button;
+        private System.Windows.Forms.TextBox SlackCompensationDistance_textBox;
     }
 }
 

--- a/LitePlacer/MainForm.cs
+++ b/LitePlacer/MainForm.cs
@@ -368,6 +368,8 @@ namespace LitePlacer
 
             Cnc.SlackCompensation = Setting.CNC_SlackCompensation;
             SlackCompensation_checkBox.Checked = Setting.CNC_SlackCompensation;
+            Cnc.SlackCompensationDistance = Setting.CNC_SlackCompensationDistance;
+            SlackCompensationDistance_textBox.Text = Setting.CNC_SlackCompensationDistance.ToString();
             Cnc.SlackCompensationA = Setting.CNC_SlackCompensationA;
             SlackCompensationA_checkBox.Checked = Setting.CNC_SlackCompensationA;
             Cnc.SmallMovementString = "G1 F" + Setting.CNC_SmallMovementSpeed + " ";
@@ -6499,6 +6501,20 @@ namespace LitePlacer
             }
         }
 
+        private void SlackCompensationDistance_textBox_KeyPress(object sender, KeyPressEventArgs e)
+        {
+            double val;
+            SlackCompensationDistance_textBox.ForeColor = Color.Red;
+            if (e.KeyChar == '\r')
+            {
+                if (double.TryParse(SlackCompensationDistance_textBox.Text.Replace(',', '.'), out val))
+                {
+                    Setting.CNC_SlackCompensationDistance = val;
+                    Cnc.SlackCompensationDistance = Setting.CNC_SlackCompensationDistance;
+                    SlackCompensationDistance_textBox.ForeColor = Color.Black;
+                }
+            }
+        }
 
         private static int SetProbing_stage = 0;
 
@@ -15577,8 +15593,6 @@ namespace LitePlacer
         {
             CNC_RawWrite("{\"gc\":\"G28.3 A0\"}");
         }
-
-
     }	// end of: 	public partial class FormMain : Form
 
 

--- a/LitePlacer/MainForm.resx
+++ b/LitePlacer/MainForm.resx
@@ -255,6 +255,15 @@
   <metadata name="SizeY.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="PartialName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="SizeX.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="SizeY.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="dataGridViewComboBoxColumn11.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -274,6 +283,48 @@
     <value>True</value>
   </metadata>
   <metadata name="dataGridViewTextBoxColumn60.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewComboBoxColumn11.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewCheckBoxColumn11.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn56.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn57.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn58.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn59.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn60.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Funct_column.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Enabled_column.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Int1_column.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Double1_column.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="R_column.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="G_column.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="B_column.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="Funct_column.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -318,6 +369,30 @@
   <metadata name="dataGridViewTextBoxColumn10.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="dataGridViewComboBoxColumn3.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewCheckBoxColumn3.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn6.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn7.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn8.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn9.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn10.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>366, 6</value>
+  </metadata>
   <data name="label135.ToolTip" xml:space="preserve">
     <value>Camera switching methods:
 Fast: Uncheck both. Fastest and uses least resources, may cause issues on some systems
@@ -336,6 +411,27 @@ needs more USB and system resources.
 
 Best and most reliable method is unfortunately system dependent.</value>
   </data>
+  <metadata name="dataGridViewComboBoxColumn9.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewCheckBoxColumn9.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn41.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn42.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn43.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn44.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn45.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="dataGridViewComboBoxColumn9.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -387,6 +483,27 @@ Best and most reliable method is unfortunately system dependent.</value>
   <metadata name="dataGridViewTextBoxColumn25.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="dataGridViewComboBoxColumn5.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewCheckBoxColumn5.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn21.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn22.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn23.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn24.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn25.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="dataGridViewComboBoxColumn6.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -406,6 +523,48 @@ Best and most reliable method is unfortunately system dependent.</value>
     <value>True</value>
   </metadata>
   <metadata name="dataGridViewTextBoxColumn30.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewComboBoxColumn6.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewCheckBoxColumn6.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn26.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn27.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn28.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn29.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn30.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewComboBoxColumn7.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewCheckBoxColumn7.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn31.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn32.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn33.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn34.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn35.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="dataGridViewComboBoxColumn7.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -450,6 +609,27 @@ Best and most reliable method is unfortunately system dependent.</value>
   <metadata name="dataGridViewTextBoxColumn15.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="dataGridViewComboBoxColumn1.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewCheckBoxColumn1.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn11.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn12.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn13.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn14.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn15.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="dataGridViewComboBoxColumn4.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -469,6 +649,48 @@ Best and most reliable method is unfortunately system dependent.</value>
     <value>True</value>
   </metadata>
   <metadata name="dataGridViewTextBoxColumn20.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewComboBoxColumn4.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewCheckBoxColumn4.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn16.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn17.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn18.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn19.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn20.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Function.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Active.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Parameter_int.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Parameter_double.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Parameter_R.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Parameter_G.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Parameter_B.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="Function.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -513,6 +735,27 @@ Best and most reliable method is unfortunately system dependent.</value>
   <metadata name="dataGridViewTextBoxColumn5.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="dataGridViewComboBoxColumn2.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewCheckBoxColumn2.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn1.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn2.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn3.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn4.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn5.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="dataGridViewComboBoxColumn10.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -532,6 +775,48 @@ Best and most reliable method is unfortunately system dependent.</value>
     <value>True</value>
   </metadata>
   <metadata name="dataGridViewTextBoxColumn50.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewComboBoxColumn10.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewCheckBoxColumn10.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn46.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn47.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn48.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn49.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn50.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewComboBoxColumn8.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewCheckBoxColumn8.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn36.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn37.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn38.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn39.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn40.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="dataGridViewComboBoxColumn8.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">

--- a/LitePlacer/Properties/Settings.Designer.cs
+++ b/LitePlacer/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace LitePlacer.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.0.1.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.3.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -536,6 +536,18 @@ namespace LitePlacer.Properties {
             }
             set {
                 this["CNC_SlackCompensation"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0.4")]
+        public double CNC_SlackCompensationDistance {
+            get {
+                return ((double)(this["CNC_SlackCompensationDistance"]));
+            }
+            set {
+                this["CNC_SlackCompensationDistance"] = value;
             }
         }
         

--- a/LitePlacer/Properties/Settings.settings
+++ b/LitePlacer/Properties/Settings.settings
@@ -131,6 +131,9 @@
     <Setting Name="CNC_SlackCompensation" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="CNC_SlackCompensationDistance" Type="System.Double" Scope="User">
+      <Value Profile="(Default)">0.4</Value>
+    </Setting>
     <Setting Name="General_Mark1X" Type="System.Double" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>

--- a/LitePlacer/app.config
+++ b/LitePlacer/app.config
@@ -137,7 +137,10 @@
             <setting name="CNC_SlackCompensation" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="General_Mark1X" serializeAs="String">
+          <setting name="CNC_SlackCompensationDistance" serializeAs="String">
+            <value>0.4</value>
+          </setting>
+          <setting name="General_Mark1X" serializeAs="String">
                 <value>0</value>
             </setting>
             <setting name="General_Mark1Y" serializeAs="String">


### PR DESCRIPTION
Exposing CNC.SlackCompensationDistance as a setting to allow user configurable Slack Compensation Distances to fully compensate Backlash.

Note: Visual Studio has created some large diffs in the Designer files compared to the original, just search for SlackCompensationDistance in these files (I haven't changed the position of all fields), only moved the checkbox and added the new field.