### PR TITLE
Manually assisted placment of parts: Fix for wrong movment at end of placment

### DIFF
--- a/LitePlacer/MainForm.cs
+++ b/LitePlacer/MainForm.cs
@@ -7768,6 +7768,8 @@ namespace LitePlacer
         // and then that row is processed.
         private void PlaceOne_button_Click(object sender, EventArgs e)
         {
+            this.ActiveControl = null; // User might need press enter during the process, which would run this again...
+            
             // Do we need to do something in the first place?
             // is something actually selected?
             if (CadData_GridView.SelectedCells.Count == 0)


### PR DESCRIPTION
**Issue**:
If manually assisted placment of parts is started from within CAD data (Place button) after pressing the enter button, the machine has performed an unintentional movement

**Cause**:
PlaceOne_button_Click() routine was not designed to press enter during processing. During manually assisted placment the focus was still on this routine. After press enter the routine was started again.