### PR TITLE
Minor spelling mistake; "top" should be "to".

### DIFF
--- a/LitePlacer/MainForm.cs
+++ b/LitePlacer/MainForm.cs
@@ -15328,7 +15328,7 @@ namespace LitePlacer
         private void AppBuiltInSettings_button_Click(object sender, EventArgs e)
         {
             DialogResult dialogResult = ShowMessageBox(
-                "Reset application settings top built in defaults?",
+                "Reset application settings to built in defaults?",
                 "Confirm Loading Built-In settings", MessageBoxButtons.YesNo);
             if (dialogResult == DialogResult.No)
             {


### PR DESCRIPTION
In the function AppBuiltInSettings_button_Click in MainForm.cs at line 15138, the string "Reset application settings top built in defaults?" should read "Reset application settings to built in defaults?".