### PR TITLE
Bug fixes jn

### DIFF
--- a/LitePlacer/AppSettings.cs
+++ b/LitePlacer/AppSettings.cs
@@ -1,12 +1,12 @@
 ﻿//#define TRANSFER
 
-/* 
+/*
 
  Using the standard method (Settings.settings file, Setting.xxx) was a mistake:
  No easy recovery, impossible to move installation from one machine to another, to name a few.
  This class resolves the issues. See
  http://stackoverflow.com/questions/453161/best-practice-to-save-application-settings-in-a-windows-forms-application,
- Trevor's answer (second answer from top). Also, to get a nice formatting (each parameter on its own line), 
+ Trevor's answer (second answer from top). Also, to get a nice formatting (each parameter on its own line),
  Newtonsoft.Json library is used. http://www.newtonsoft.com/json
 
  If you uncomment the first line, you get a version that transfers the settings from old version to new.
@@ -165,7 +165,7 @@ namespace LitePlacer
     }
 
     // =================================================================================
-    // 
+    //
     // =================================================================================
     public class AppSettings
     {
@@ -217,6 +217,14 @@ namespace LitePlacer
                 {
                     MainForm.DisplayText("Reading " + FileName);
                     settings = JsonConvert.DeserializeObject<MySettings>(File.ReadAllText(FileName));
+
+                    // JsonConvert.DeserializeObject can return null if the setings file is corrupt,
+                    // catch this here and inform the operator before we cause a NullReferenceException in Form1_Load.
+                    if (settings == null)
+                    {
+                        throw new Exception($"Couldn't load {FileName}. File exists but is corrupt.");
+                    }
+
                     return settings;
                 }
                 else

--- a/LitePlacer/MainForm.cs
+++ b/LitePlacer/MainForm.cs
@@ -42,8 +42,8 @@ namespace LitePlacer
 #pragma warning disable CA1308 // Yes, we want to use lower case characters
     /*
     Note: For function success/failure, I use bool return code. (instead of C# exceptions; a philosophical debate, let's not go there too much.
-    Still, it should be mentioned that CA1031 is supressed: I think the right way is to tell the user and continue. For example: A save fails; tell the user, 
-    Let h** to free room on the disk, plug in tehe USB stick, whatever, and let h** to try again. 
+    Still, it should be mentioned that CA1031 is supressed: I think the right way is to tell the user and continue. For example: A save fails; tell the user,
+    Let h** to free room on the disk, plug in tehe USB stick, whatever, and let h** to try again.
 
     The naming convention is xxx_m() for functions that have already displayed an error message to user. If a function only
     calls _m functions, it can consider itself a _m function.
@@ -64,14 +64,14 @@ namespace LitePlacer
         AppSettings SettingsOps;
 
         // =================================================================================
-        // General and "global" functions 
+        // General and "global" functions
         // =================================================================================
         #region General
 
         // =================================================================================
-        // Note about thread guards: The prologue "if(InvokeRequired) {something long}" at a start of a function, 
+        // Note about thread guards: The prologue "if(InvokeRequired) {something long}" at a start of a function,
         // makes the function safe to call from another thread.
-        // See http://stackoverflow.com/questions/661561/how-to-update-the-gui-from-another-thread-in-c, 
+        // See http://stackoverflow.com/questions/661561/how-to-update-the-gui-from-another-thread-in-c,
         // "MajesticRa"'s answer near the bottom of first page
 
 
@@ -280,7 +280,7 @@ namespace LitePlacer
             if (UpdateAvailable(out UpdateText))
             {
                 ShowMessageBox(
-                    "There is software update available:\n\r" + UpdateText,
+                    "There is a software update available:\n\r" + UpdateText,
                     "Update available",
                     MessageBoxButtons.OK);
                 return true;
@@ -550,7 +550,7 @@ namespace LitePlacer
             if (!OK)
             {
                 DialogResult dialogResult = ShowMessageBox(
-                    "some data could not be saved (see log window). Quit anyway?",
+                    "Some data could not be saved (see log window). Quit anyway?",
                     "Data save problem", MessageBoxButtons.YesNo);
                 if (dialogResult == DialogResult.No)
                 {
@@ -668,12 +668,12 @@ namespace LitePlacer
         // Saving and restoring data tables (Note: Not job files)
         // =================================================================================
 
-        // Reading ver2 format allows changing the data grid itself at a software update, 
+        // Reading ver2 format allows changing the data grid itself at a software update,
         // adding and removing columns, and still read in a saved file from previous software version.
 
         public enum DataTableType { Tapes, ComponentData, VideoProcessing, PanelFiducials, Nozzles };
 
-        private int Ver2FormatID = 20000001;  // Just in case we need to identify the format we are using. 
+        private int Ver2FormatID = 20000001;  // Just in case we need to identify the format we are using.
         public bool LoadingDataGrid { get; set; } = false;  // to avoid problems with cell value changed event and unfilled grids
 
 
@@ -1128,7 +1128,7 @@ namespace LitePlacer
                     }
                     else
                     {
-                        // read in new format 
+                        // read in new format
                         DisplayText("Loading tapes with nozzles data");
                         LoadDataGrid(filename, Tapes_dataGridView, DataTableType.Tapes);
                     }
@@ -1472,7 +1472,7 @@ namespace LitePlacer
             }
             if (
                 ((Cnc.CurrentZ > 5) && ZguardIsOn())
-                && 
+                &&
                 !((e.KeyCode == Keys.F11) || (e.KeyCode == Keys.F12)))  // F11&F12: It is ok to move z manually
             {
                 DisplayText("Nozzle is down", KnownColor.DarkRed, true);
@@ -2998,7 +2998,7 @@ namespace LitePlacer
             {
                 return false;
             }
-            // Measure 7 times, get median: 
+            // Measure 7 times, get median:
             List<double> Xlist = new List<double>();
             List<double> Ylist = new List<double>();
             int res;
@@ -3131,7 +3131,7 @@ namespace LitePlacer
 
         private void StartCameras()
         {
-            // Called at startup. 
+            // Called at startup.
             DownCamera.Active = false;
             UpCamera.Active = false;
             DownCamera.Close();
@@ -3523,7 +3523,7 @@ namespace LitePlacer
         }
 
         // =================================================================================
-        // get the devices         
+        // get the devices
         private void getDownCamList()
         {
             List<string> Devices = DownCamera.GetDeviceList();
@@ -4682,7 +4682,7 @@ namespace LitePlacer
         private bool ControlBoardJustConnected()
         {
             // Called when control board conenction is estabished.
-            // First, find out the board type. Then, 
+            // First, find out the board type. Then,
             // for TinyG boards, read the parameter values stored on board.
             // For qQuintic boards that dont' have on-board storage, write the values.
 
@@ -5422,7 +5422,7 @@ namespace LitePlacer
         {
             if (InvokeRequired) { Invoke(new Action<string>(Update_xsv), new[] { value }); return; }
 
-            int ind = value.IndexOf('.');   // Cut off the decimal portion, otherwise convert fails in some non-US cultures 
+            int ind = value.IndexOf('.');   // Cut off the decimal portion, otherwise convert fails in some non-US cultures
             if (ind > 0)
             {
                 value = value.Substring(0, ind);
@@ -5435,7 +5435,7 @@ namespace LitePlacer
         {
             if (InvokeRequired) { Invoke(new Action<string>(Update_ysv), new[] { value }); return; }
 
-            int ind = value.IndexOf('.');   // Cut off the decimal portion, otherwise convert fails in some non-US cultures 
+            int ind = value.IndexOf('.');   // Cut off the decimal portion, otherwise convert fails in some non-US cultures
             if (ind > 0)
             {
                 value = value.Substring(0, ind);
@@ -5448,7 +5448,7 @@ namespace LitePlacer
         {
             if (InvokeRequired) { Invoke(new Action<string>(Update_zsv), new[] { value }); return; }
 
-            int ind = value.IndexOf('.');   // Cut off the decimal portion, otherwise convert fails in some non-US cultures 
+            int ind = value.IndexOf('.');   // Cut off the decimal portion, otherwise convert fails in some non-US cultures
             if (ind > 0)
             {
                 value = value.Substring(0, ind);
@@ -5722,7 +5722,7 @@ namespace LitePlacer
         {
             if (InvokeRequired) { Invoke(new Action<string>(Update_xvm), new[] { value }); return; }
 
-            int ind = value.IndexOf('.');   // Cut off the decimal portion, otherwise convert fails in some non-US cultures 
+            int ind = value.IndexOf('.');   // Cut off the decimal portion, otherwise convert fails in some non-US cultures
             if (ind > 0)
             {
                 value = value.Substring(0, ind);
@@ -5736,7 +5736,7 @@ namespace LitePlacer
         {
             if (InvokeRequired) { Invoke(new Action<string>(Update_yvm), new[] { value }); return; }
 
-            int ind = value.IndexOf('.');   // Cut off the decimal portion, otherwise convert fails in some non-US cultures 
+            int ind = value.IndexOf('.');   // Cut off the decimal portion, otherwise convert fails in some non-US cultures
             if (ind > 0)
             {
                 value = value.Substring(0, ind);
@@ -5750,7 +5750,7 @@ namespace LitePlacer
         {
             if (InvokeRequired) { Invoke(new Action<string>(Update_zvm), new[] { value }); return; }
 
-            int ind = value.IndexOf('.');   // Cut off the decimal portion, otherwise convert fails in some non-US cultures 
+            int ind = value.IndexOf('.');   // Cut off the decimal portion, otherwise convert fails in some non-US cultures
             if (ind > 0)
             {
                 value = value.Substring(0, ind);
@@ -5764,7 +5764,7 @@ namespace LitePlacer
         {
             if (InvokeRequired) { Invoke(new Action<string>(Update_avm), new[] { value }); return; }
 
-            int ind = value.IndexOf('.');   // Cut off the decimal portion, otherwise convert fails in some non-US cultures 
+            int ind = value.IndexOf('.');   // Cut off the decimal portion, otherwise convert fails in some non-US cultures
             if (ind > 0)
             {
                 value = value.Substring(0, ind);
@@ -7724,7 +7724,7 @@ namespace LitePlacer
 
             if (JobData_GridView.CurrentCell.ColumnIndex == Jobdata_MethodParametersColumn)
             {
-                // For method parameter, show the tape selection form if method is "place" 
+                // For method parameter, show the tape selection form if method is "place"
                 MakeJobDataDirty();
                 string TapeID;
                 int TapeNo;
@@ -8060,7 +8060,7 @@ namespace LitePlacer
             string[] Components;  // This array has the list of components to place:
             string NewID = "";
             bool RestoreRow = false;
-            // RestoreRow: If we'll replace the jobdata row with new data at the end. 
+            // RestoreRow: If we'll replace the jobdata row with new data at the end.
             // There isn't any new data, unless method is "?".
 
             // If the Method is "?", ask the user what to do:
@@ -8545,7 +8545,7 @@ namespace LitePlacer
                 return false;
             }
 
-            // Component is at CadData_GridView.Rows[CADdataRow]. 
+            // Component is at CadData_GridView.Rows[CADdataRow].
             // What to do to it is at  JobData_GridView.Rows[GroupRow].
 
             int time;
@@ -8626,7 +8626,7 @@ namespace LitePlacer
 
                 case "Fiducials":
                     return true;  // To next row...
-                // break; 
+                // break;
 
 
                 // Used this for debugging, but is unreachable now
@@ -9095,7 +9095,7 @@ namespace LitePlacer
         }
 
         // =================================================================================
-        // PutPartDown_m(): Puts part down at this position. 
+        // PutPartDown_m(): Puts part down at this position.
         // If placement Z isn't known already, updates the tape info.
         private bool PutPartDown_m(int TapeNum)
         {
@@ -9146,7 +9146,7 @@ namespace LitePlacer
         }
 
         // =================================================================================
-        // 
+        //
         private bool PutLoosePartDown_m(bool Probe)
         {
             if (Probe)
@@ -9181,7 +9181,7 @@ namespace LitePlacer
         // fine tuning of the position.
         // After done ENTER will trigger the final placement.
         //
-        // MethodeParameter: For Loose Part Assisted => stop distance above board in mm 
+        // MethodeParameter: For Loose Part Assisted => stop distance above board in mm
         // ====================================================================================
         private bool PutLoosePartDownAssisted_m(string MethodParameter)
         {
@@ -9220,7 +9220,7 @@ namespace LitePlacer
 
             ZGuardOff(); // Allow nozzle movment while nozzle is down
 
-            // Wait for enter key pressed. 
+            // Wait for enter key pressed.
             EnterKeyHit = false;
             do
             {
@@ -9272,7 +9272,7 @@ namespace LitePlacer
         }
 
         // =================================================================================
-        // Actual placement 
+        // Actual placement
         // =================================================================================
         private double LoosePartPickupZ = 0.0;
         private double LoosePartPlaceZ = 0.0;
@@ -9332,7 +9332,7 @@ namespace LitePlacer
                 return false;
             }
 
-            // ask for it 
+            // ask for it
             string ComponentType = CadData_GridView.Rows[CADdataRow].Cells["Value_Footprint"].Value.ToString();
             DialogResult dialogResult = ShowMessageBox(
                 "Put one " + ComponentType + " to the pickup location.",
@@ -9445,8 +9445,8 @@ namespace LitePlacer
 
         // ========================================================================================
         // PlacePart_m(): This routine places a single component.
-        // Component is at CadData_GridView.Rows[CADdataRow]. 
-        // Tape ID and method are at JobDataRow.Rows[JobDataRow]. 
+        // Component is at CadData_GridView.Rows[CADdataRow].
+        // Tape ID and method are at JobDataRow.Rows[JobDataRow].
         // It should go to X, Y, A
         // CAD data is validated already.
 
@@ -9571,7 +9571,7 @@ namespace LitePlacer
                 DownCamera.RotateSnapshot(A);
                 if (!CNC_XYA_m(X, Y, A))
                 {
-                    // VacuumOff();  if the above failed CNC seems to be down; low chances that VacuumOff() would go thru either. 
+                    // VacuumOff();  if the above failed CNC seems to be down; low chances that VacuumOff() would go thru either.
                     DownCamera.Draw_Snapshot = false;
                     return false;
                 };
@@ -9605,7 +9605,7 @@ namespace LitePlacer
             DisplayText("PlacePart_m: goto placement position");
             if (!Nozzle.Move_m(X, Y, A))
             {
-                // VacuumOff();  if the above failed CNC seems to be down; low chances that VacuumOff() would go thru either. 
+                // VacuumOff();  if the above failed CNC seems to be down; low chances that VacuumOff() would go thru either.
                 DownCamera.Draw_Snapshot = false;
                 UpCamera.Draw_Snapshot = false;
                 return false;
@@ -9634,14 +9634,14 @@ namespace LitePlacer
                     // since for tape parts id contains the Tape index, we use here a fixed stop distance above board
                     if (!PutLoosePartDownAssisted_m("2.5"))
                     {
-                        // VacuumOff();  if this failed CNC seems to be down; low chances that VacuumOff() would go thru either. 
+                        // VacuumOff();  if this failed CNC seems to be down; low chances that VacuumOff() would go thru either.
                         return false;
                     }
                     break;
                 case "LoosePart Assisted":
                     if (!PutLoosePartDownAssisted_m(id)) // id contains stop distance above board
                     {
-                        // VacuumOff();  if this failed CNC seems to be down; low chances that VacuumOff() would go thru either. 
+                        // VacuumOff();  if this failed CNC seems to be down; low chances that VacuumOff() would go thru either.
                         return false;
                     }
                     break;
@@ -9652,7 +9652,7 @@ namespace LitePlacer
                     UpCamera.Draw_Snapshot = false;
                     if (!PutLoosePartDown_m(FirstInRow))
                     {
-                        // VacuumOff();  if this failed CNC seems to be down; low chances that VacuumOff() would go thru either. 
+                        // VacuumOff();  if this failed CNC seems to be down; low chances that VacuumOff() would go thru either.
                         return false;
                     }
                     break;
@@ -9660,7 +9660,7 @@ namespace LitePlacer
                 default:
                     if (!PutPartDown_m(TapeNum))
                     {
-                        // VacuumOff();  if this failed CNC seems to be down; low chances that VacuumOff() would go thru either. 
+                        // VacuumOff();  if this failed CNC seems to be down; low chances that VacuumOff() would go thru either.
                         DownCamera.Draw_Snapshot = false;
                         UpCamera.Draw_Snapshot = false;
                         return false;
@@ -9776,7 +9776,7 @@ namespace LitePlacer
         }
 
         // =================================================================================
-        // BuildMachineCoordinateData_m routine builds the machine coordinates data 
+        // BuildMachineCoordinateData_m routine builds the machine coordinates data
         // based on fiducials true (machine coord) location.
         // =================================================================================
 
@@ -10065,7 +10065,7 @@ namespace LitePlacer
                         return false;
                     }
                 }
-                // We could put the machine data in place at this point. However, 
+                // We could put the machine data in place at this point. However,
                 // we don't, as if the algorithms below are correct, the data will not change more than measurement error.
                 // During development, that is a good checkpoint.
             }
@@ -10227,7 +10227,7 @@ namespace LitePlacer
                     return false;
                 }
             }
-            // Done! 
+            // Done!
             ValidMeasurement_checkBox.Checked = true;
             return true;
         }// end BuildMachineCoordinateData_m
@@ -10372,7 +10372,7 @@ namespace LitePlacer
 
 
         // =================================================================================
-        // Checks what is needed to check before doing something for a single component selected at "CAD data" table. 
+        // Checks what is needed to check before doing something for a single component selected at "CAD data" table.
         // If succesful, sets X, Y to component machine coordinates.
         private bool PrepareSingleComponentOperation(out double X, out double Y)
         {
@@ -10903,7 +10903,7 @@ namespace LitePlacer
         // =================================================================================
 
         // =================================================================================
-        // FindDelimiter_m(): Tries to find the difference with comma and semicolon separated files  
+        // FindDelimiter_m(): Tries to find the difference with comma and semicolon separated files
         bool FindDelimiter_m(String Line, out char delimiter)
         {
             int commas = 0;
@@ -10957,7 +10957,7 @@ namespace LitePlacer
             int LineIndex = 0;
             int i;
 
-            // Parse header. 
+            // Parse header.
             string FirstLine = AllLines[0];
             if (FirstLine == "Altium Designer Pick and Place Locations")
             {
@@ -11281,7 +11281,7 @@ namespace LitePlacer
                 CadData_GridView.Rows[Last].Cells["Y_nominal"].Value = Line[Y_Nominal_Index].Replace("mm", "");
                 CadData_GridView.Rows[Last].Cells["X_nominal"].Value = CadData_GridView.Rows[Last].Cells["X_nominal"].Value.ToString().Replace(",", ".");
                 CadData_GridView.Rows[Last].Cells["Y_nominal"].Value = CadData_GridView.Rows[Last].Cells["Y_nominal"].Value.ToString().Replace(",", ".");
-                CadData_GridView.Rows[Last].Cells["X_Machine"].Value = "Nan";   // will be set later 
+                CadData_GridView.Rows[Last].Cells["X_Machine"].Value = "Nan";   // will be set later
                 CadData_GridView.Rows[Last].Cells["Y_Machine"].Value = "Nan";
                 CadData_GridView.Rows[Last].Cells["Rotation_machine"].Value = "Nan";
             }   // end "for each component..."
@@ -11303,7 +11303,7 @@ namespace LitePlacer
 
         // =================================================================================
         // HandleDuplicates():
-        // If the inout data has duplicate designators, like R1, R1, R1, this routine 
+        // If the inout data has duplicate designators, like R1, R1, R1, this routine
         // replaces them with R1_1, R1_2, R1_3 etc.
 
         public void HandleDuplicates(ref List<List<string>> DataLines, int ComponentIndex)
@@ -11686,12 +11686,12 @@ namespace LitePlacer
             // Rotation_Column: Which way the parts are rotated on the tape. if 0, parts form +Y oriented tape
             // correspont to 0deg. on the PCB, tape.e. the placement operation does not rotate them.
             Tapes_dataGridView.Rows[index].Cells["Rotation_Column"].Value = "0deg.";
-            // WidthColumn: sets the width of the tape and the distance from one part to next. 
+            // WidthColumn: sets the width of the tape and the distance from one part to next.
             // From EIA-481, we get the part location from the hole location.
             Tapes_dataGridView.Rows[index].Cells["Width_Column"].Value = "8/4mm";
             // Type_Column: used in hole recognition
             Tapes_dataGridView.Rows[index].Cells["Type_Column"].Value = "Paper (White)";
-            // NextPart_Column tells the part number of next part. 
+            // NextPart_Column tells the part number of next part.
             // NextX, NextY tell the approximate hole location for the next part. Incremented when a part is picked up.
             Tapes_dataGridView.Rows[index].Cells["NextPart_Column"].Value = "1";
             Tapes_dataGridView.Rows[index].Cells["Next_X_Column"].Value = Cnc.CurrentX.ToString("0.000", CultureInfo.InvariantCulture);
@@ -11770,8 +11770,8 @@ namespace LitePlacer
 
 
         // ==========================================================================================================
-        // Tapes_dataGridView_CellClick(): 
-        // If the click is on a button column, resets the tape. 
+        // Tapes_dataGridView_CellClick():
+        // If the click is on a button column, resets the tape.
         private void Tapes_dataGridView_CellClick(object sender, DataGridViewCellEventArgs e)
         {
             // Ignore clicks that are not on button cell  Id_Column
@@ -11784,7 +11784,7 @@ namespace LitePlacer
         }
 
         // ==========================================================================================================
-        // SelectTape(): 
+        // SelectTape():
         // Displays a dialog with buttons for all defined tapes, returns the ID of the tape.
         // used in placement when the user selects the tape to be used in runtime.
         // In this case, we remove the regular Tapes_dataGridView_CellClick() handler; the TapeDialog
@@ -12087,8 +12087,8 @@ namespace LitePlacer
 
         private void Tapes_dataGridView_CurrentCellDirtyStateChanged(object sender, EventArgs e)
         {
-            // This event handler manually raises the CellValueChanged event 
-            // by calling the CommitEdit method. 
+            // This event handler manually raises the CellValueChanged event
+            // by calling the CommitEdit method.
             if (Tapes_dataGridView.IsCurrentCellDirty)
             {
                 // This fires the cell value changed handler below
@@ -12225,7 +12225,7 @@ namespace LitePlacer
 
         private void LoadTrayFromFile(string FileName)
         {
-            // from: http://stackoverflow.com/questions/6336239/copy-datagridviews-rows-into-another-datagridview  
+            // from: http://stackoverflow.com/questions/6336239/copy-datagridviews-rows-into-another-datagridview
             DataGridView ClipBoard_dgw = new DataGridView();
             ClipBoard_dgw.AllowUserToAddRows = false;  // this prevents an empty row in the end
             foreach (DataGridViewColumn col in Tapes_dataGridView.Columns)
@@ -13486,7 +13486,7 @@ namespace LitePlacer
             };
             switch (Display_dataGridView.Rows[row].Cells[FunctCol].Value.ToString())
             {
-                // switch by the selected algorithm:  
+                // switch by the selected algorithm:
                 case "Blur":
                     ClearParameterValuesExcept(row, -1);
                     return;		// no parameters
@@ -14229,7 +14229,7 @@ namespace LitePlacer
             {
                 ZGuardOn();
             }
-            // disable z switches, otherwise you can't do setup 
+            // disable z switches, otherwise you can't do setup
             ZGuardOff();
             CNC_Write_m("{\"zsn\":0}");
             Thread.Sleep(50);
@@ -14653,7 +14653,7 @@ namespace LitePlacer
             CNC_timeout = Setting.Nozzles_Timeout;
 
             bool ok = true;
-            // disable z switches 
+            // disable z switches
             ZGuardOff();
             CNC_Write_m("{\"zsn\":0}");
             Thread.Sleep(50);
@@ -15815,7 +15815,7 @@ namespace LitePlacer
 
 
     // ===================================================================================
-    // allows addition of color info to displayText 
+    // allows addition of color info to displayText
     public static class RichTextBoxExtensions
     {
         public static void AppendText(this RichTextBox box, string text, Color color)

--- a/LitePlacer/SerialComm.cs
+++ b/LitePlacer/SerialComm.cs
@@ -13,7 +13,7 @@ namespace LitePlacer
 
     class SerialComm
     {
-        
+
         SerialPort Port = new SerialPort();
 
         // To process data on the DataReceived thread, get reference of Cnc, so we can pass data to it.
@@ -30,8 +30,8 @@ namespace LitePlacer
 
         public bool IsOpen
         {
-            get 
-            { 
+            get
+            {
                 return Port.IsOpen;
             }
         }
@@ -57,10 +57,11 @@ namespace LitePlacer
                     Port.DiscardInBuffer();
                     Port.DiscardOutBuffer();
                 }
-                // Known issue: Sometimes serial port hangs in app closing. Google says that 
+                // Known issue: Sometimes serial port hangs in app closing. Google says that
                 // the workaround is to close in another thread
                 Thread t = new Thread(() => Close_thread());
                 t.Start();
+                t.Join(); // Wait until the port has been closed.
             }
             catch
             {
@@ -135,14 +136,14 @@ namespace LitePlacer
 
         void DataReceived(object sender, SerialDataReceivedEventArgs e)
         {
-            //Initialize a buffer to hold the received data 
+            //Initialize a buffer to hold the received data
             byte[] buffer = new byte[ReadBufferSize];
             string WorkingString;
 
             try
             {
-                //There is no accurate method for checking how many bytes are read 
-                //unless you check the return from the Read method 
+                //There is no accurate method for checking how many bytes are read
+                //unless you check the return from the Read method
                 int bytesRead = Port.Read(buffer, 0, buffer.Length);
 
                 //The received data is ASCII
@@ -150,9 +151,9 @@ namespace LitePlacer
                 //Process each line
                 while (RxString.IndexOf("\n", StringComparison.Ordinal) > -1)
                 {
-                        //Even when RxString does contain terminator we cannot assume that it is the last character received 
+                        //Even when RxString does contain terminator we cannot assume that it is the last character received
                         WorkingString = RxString.Substring(0, RxString.IndexOf("\n", StringComparison.Ordinal) +1);
-                        //Remove the data and the terminator from tString 
+                        //Remove the data and the terminator from tString
                         RxString = RxString.Substring(RxString.IndexOf("\n", StringComparison.Ordinal) + 1);
                         Cnc.InterpretLine(WorkingString);
                 }
@@ -163,7 +164,7 @@ namespace LitePlacer
                 // MainForm.DisplayText("########## " + ex);
             }
 #pragma warning restore CA1031 // Do not catch general exception types
-        } 
+        }
 
      }
 }


### PR DESCRIPTION
3 Changes in this pull request:

**AppSettings.cs:**
Handling the case when JsonConvert.DeserializeObject<MySettings>(File.ReadAllText(FileName)); returns null. Which it can if the file exists but is empty or corrupt. This happened to me yesterday :(. In the case of it returning null, the operator will be informed and the program will continue with default settings. If Load() was to return null, a NullReferenceException would occur in MainForm.Form1_Load(). I'm tempted to write a settings file backup system that will keep a number of previously known good configurations.

**MainForm.cs:**
Only changed two strings:
"There is software update available:\n\r" -> "There is **a** software update available:\n\r"
"some data could not be saved (see log window). Quit anyway?" -> "**S**ome data could not be saved (see log window). Quit anyway?"

**SerialComm.cs:**
Calling t.Join() in the Close() function to guarantee that the thread which closes the serial port has completed before the Close() function returns.


PS appologies for all the white space changes, I have VS setup to trim white space at the end of lines automatically. I should probably turn that off when working on open source projects.