### PR TITLE
Camera related fixes and additions

### DIFF
--- a/LitePlacer/IAMVideoProcAmp.cs
+++ b/LitePlacer/IAMVideoProcAmp.cs
@@ -1,0 +1,81 @@
+﻿// AForge Direct Show Library
+// AForge.NET framework
+// http://www.aforgenet.com/framework/
+//
+// Copyright © AForge.NET, 2009-2013
+// contacts@aforgenet.com
+//
+
+namespace AForge.Video.DirectShow.Internals
+{
+    using System;
+    using System.Runtime.InteropServices;
+
+    /// <summary>
+    /// The IAMVideoProcAmp interface controls camera settings such as brightness, contrast, hue,
+    /// or saturation. To obtain this interface, query the filter that controls the camera.
+    /// </summary>
+    [ComImport,
+    Guid("C6E13360-30AC-11D0-A18C-00A0C9118956"),
+    InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IAMVideoProcAmp
+    {
+        /// <summary>
+        /// Gets the range and default value of a specified camera property.
+        /// </summary>
+        ///
+        /// <param name="Property">Specifies the property to query.</param>
+        /// <param name="pMin">Receives the minimum value of the property.</param>
+        /// <param name="pMax">Receives the maximum value of the property.</param>
+        /// <param name="pSteppingDelta">Receives the step size for the property.</param>
+        /// <param name="pDefault">Receives the default value of the property. </param>
+        /// <param name="pCapsFlags">Receives a member of the VideoProcAmpFlags enumeration, indicating whether the property is controlled automatically or manually.</param>
+        ///
+        /// <returns>Return's <b>HRESULT</b> error code.</returns>
+        ///
+        [PreserveSig]
+        int GetRange(
+            [In] VideoProcAmpProperty Property,
+            [Out] out int pMin,
+            [Out] out int pMax,
+            [Out] out int pSteppingDelta,
+            [Out] out int pDefault,
+            [Out] out VideoProcAmpFlags pCapsFlags
+            );
+
+        /// <summary>
+        /// Sets a specified property on the camera.
+        /// </summary>
+        ///
+        /// <param name="Property">Specifies the property to set.</param>
+        /// <param name="lValue">Specifies the new value of the property.</param>
+        /// <param name="Flags">Specifies the desired control setting, as a member of the VideoProcAmpFlags enumeration.</param>
+        ///
+        /// <returns>Return's <b>HRESULT</b> error code.</returns>
+        ///
+        [PreserveSig]
+        int Set(
+            [In] VideoProcAmpProperty Property,
+            [In] int lValue,
+            [In] VideoProcAmpFlags Flags
+            );
+
+        /// <summary>
+        /// Gets the current setting of a camera property.
+        /// </summary>
+        ///
+        /// <param name="Property">Specifies the property to retrieve.</param>
+        /// <param name="lValue">Receives the value of the property.</param>
+        /// <param name="Flags">Receives a member of the VideoProcAmpFlags enumeration.
+        /// The returned value indicates whether the setting is controlled manually or automatically.</param>
+        ///
+        /// <returns>Return's <b>HRESULT</b> error code.</returns>
+        ///
+        [PreserveSig]
+        int Get(
+            [In] VideoProcAmpProperty Property,
+            [Out] out int lValue,
+            [Out] out VideoProcAmpFlags Flags
+            );
+    }
+}

--- a/LitePlacer/MainForm.cs
+++ b/LitePlacer/MainForm.cs
@@ -23,7 +23,7 @@ using System.Windows.Media;
 using System.Windows.Input;
 using System.Net;
 
-using MathNet.Numerics;
+//using MathNet.Numerics;
 using HomographyEstimation;
 
 using AForge;
@@ -2820,11 +2820,11 @@ namespace LitePlacer
                 DisplayText("Selecting, no camera");
                 return;
             }
+            DownCamera.Active = false;
+            UpCamera.Active = false;
+            cam.Active = true;
             if (KeepActive_checkBox.Checked)
             {
-                DownCamera.Active = false;
-                UpCamera.Active = false;
-                cam.Active = true;
                 if (cam == DownCamera)
                 {
                     DisplayText("DownCamera activated");
@@ -3078,16 +3078,8 @@ namespace LitePlacer
             UpCamDrawCross_checkBox.Checked = UpCamera.DrawCross;
             UpCamDrawBox_checkBox.Checked = UpCamera.DrawBox;
 
-            if (DownCamera.Active)
-            {
-                DownCameraStatus_label.Text = "Active";
-                UpCameraStatus_label.Text = "Not Active";
-            }
-            else
-            {
-                DownCameraStatus_label.Text = "Not Active";
-                UpCameraStatus_label.Text = "Active";
-            }
+            DownCameraStatus_label.Text = DownCamera.Active ? "Active" : "Not Active";
+            UpCameraStatus_label.Text = UpCamera.Active ? "Active" : "Not Active";
 
             NozzleOffset_label.Visible = false;
 
@@ -10502,14 +10494,17 @@ namespace LitePlacer
  
         private void PickColor(int X, int Y)
         {
+            Bitmap img = new Bitmap(Cam_pictureBox.Width, Cam_pictureBox.Height);
+            Cam_pictureBox.DrawToBitmap(img, new Rectangle(new System.Drawing.Point(0, 0), img.Size));
+
             if (X < 2)
                 X = 2;
-            if (X > (Cam_pictureBox.Width - 2))
-                X = Cam_pictureBox.Width - 2;
+            if (X > (img.Width - 2))
+                X = img.Width - 2;
             if (Y < 2)
                 Y = 2;
-            if (Y > (Cam_pictureBox.Height - 2))
-                X = Cam_pictureBox.Height - 2;
+            if (Y > (img.Height - 2))
+                X = img.Height - 2;
 
             int Rsum = 0;
             int Gsum = 0;
@@ -10519,7 +10514,6 @@ namespace LitePlacer
             byte B = 0;
             Color pixelColor;
             int deb = 0;
-            Bitmap img = (Bitmap)Cam_pictureBox.Image;
             if (img!=null)
             {
                 for (int ix = X - 2; ix <= X + 2; ix++)

--- a/LitePlacer/VideoAlgorithmsUI.cs
+++ b/LitePlacer/VideoAlgorithmsUI.cs
@@ -657,7 +657,10 @@ namespace LitePlacer
             // Re-arranges functions in the UI
             AForgeFunctionDefinition funct = VideoAlgorithms.CurrentAlgorithm.FunctionList[OldPos];
             VideoAlgorithms.CurrentAlgorithm.FunctionList.RemoveAt(OldPos);
-            VideoAlgorithms.CurrentAlgorithm.FunctionList.Insert(NewPos, funct);
+            if(VideoAlgorithms.CurrentAlgorithm.FunctionList.Count <= NewPos)
+                VideoAlgorithms.CurrentAlgorithm.FunctionList.Add(funct);
+            else
+                VideoAlgorithms.CurrentAlgorithm.FunctionList.Insert(NewPos, funct);
             int col = Functions_dataGridView.CurrentCell.ColumnIndex;
             AlgorithmChange = true;
             FillFunctionTable(VideoAlgorithms.CurrentAlgorithm.Name);

--- a/LitePlacer/VideoProcAmpProperty.cs
+++ b/LitePlacer/VideoProcAmpProperty.cs
@@ -1,0 +1,90 @@
+﻿// AForge Direct Show Library
+// AForge.NET framework
+// http://www.aforgenet.com/framework/
+//
+// Copyright © AForge.NET, 2009-2013
+// contacts@aforgenet.com
+//
+
+namespace AForge.Video.DirectShow
+{
+    using System;
+
+    /// <summary>
+    /// The enumeration specifies a setting on a camera.
+    /// </summary>
+    public enum VideoProcAmpProperty
+    {
+        /// <summary>
+        /// Brightness control.
+        /// </summary>
+        Brightness = 0,
+
+        /// <summary>
+        /// Contrast control.
+        /// </summary>
+        Contrast,
+
+        /// <summary>
+        /// Hue control.
+        /// </summary>
+        Hue,
+
+        /// <summary>
+        /// Saturation control.
+        /// </summary>
+        Saturation,
+
+        /// <summary>
+        /// Sharpness control.
+        /// </summary>
+        Sharpness,
+
+        /// <summary>
+        /// Gamma control.
+        /// </summary>
+        Gamma,
+
+        /// <summary>
+        /// ColorEnable control.
+        /// </summary>
+        ColorEnable,
+
+        /// <summary>
+        /// WhiteBalance control.
+        /// </summary>
+        WhiteBalance,
+
+        /// <summary>
+        /// BacklightCompensation control.
+        /// </summary>
+        BacklightCompensation,
+
+        /// <summary>
+        /// Gain control.
+        /// </summary>
+        Gain
+    }
+
+    /// <summary>
+    /// The enumeration defines whether a camera setting is controlled manually or automatically.
+    /// </summary>
+    [Flags]
+    public enum VideoProcAmpFlags
+    {
+        /// <summary>
+        /// No control flag.
+        /// </summary>
+        None = 0x0,
+
+        /// <summary>
+        /// Auto control Flag.
+        /// </summary>
+        Auto = 0x0001,
+
+        /// <summary>
+        /// Manual control Flag.
+        /// </summary>
+        Manual = 0x0002
+    }
+}


### PR DESCRIPTION
Commented out unused MathNet.Numerics

Added: 
- alt-click colorpick support for all cam resolutions
- camera video whitebalance, brightness, sharpness auto-adjust disabled and set to fixed values for better color recognition and smoother picture

Fixes:
- Cameras becoming inactive when going to basic setup and back
- meaurement blue and green were reversed
- crash on reordering video algorithm functions